### PR TITLE
Fix sscanf issue#74

### DIFF
--- a/Suave/Sscanf.fs
+++ b/Suave/Sscanf.fs
@@ -51,10 +51,14 @@ let rec get_formatters xs =
 /// Parse the format in 'pf' from the string 's', failing and raising an exception
 /// otherwise
 let sscanf (pf:PrintfFormat<_,_,_,_,'t>) s : 't =
-  let formatStr  = pf.Value.Replace("%%", "%")
-  let constants  = formatStr.Split(separators, StringSplitOptions.None)
-  let regex      = Regex("^" + String.Join("(.*?)", constants |> Array.map Regex.Escape) + "$")
-  let formatters = pf.Value.ToCharArray() // need original string here (possibly with "%%"s)
+  let formatStr  = pf.Value
+  let constants  = formatStr.Split([|"%%"|], StringSplitOptions.None) 
+                   |> Array.map (fun x -> x.Split(separators, StringSplitOptions.None))
+  let regexStr   = constants 
+                   |> Array.map (fun c -> c |> Array.map Regex.Escape |> String.concat "(.*?)")
+                   |> String.concat "%"
+  let regex      = Regex("^" + regexStr + "$")
+  let formatters = formatStr.ToCharArray() // need original string here (possibly with "%%"s)
                    |> Array.toList |> get_formatters
   let groups =
     regex.Match(s).Groups

--- a/Tests/Sscanf.fs
+++ b/Tests/Sscanf.fs
@@ -1,0 +1,37 @@
+﻿module Suave.Tests.Sscanf
+
+open Fuchu
+
+open Suave.Sscanf
+
+[<Tests>]
+let scan_tests =
+    testList "when scanning " [
+        testCase "with escaped % before escaped placeholder in string" <| fun _ ->
+            let result = sscanf "(%%%s,%M)" "(%hello, 4.53)"
+            Assert.Equal("should match correctly", ("hello", 4.53m), result)
+
+        // covers issue: suave/issues/74
+        testCase "with escaped % before unescaped placeholder char in string" <| fun _ ->
+            let result = sscanf "(%%const%d)" "(%const5)"
+            Assert.Equal("should match correctly", (5), result)
+
+        testCase "with escaped % before non-placeholder char in string" <| fun _ ->
+            let result = sscanf "(%%hello%s,%M)" "(%helloWorld, 4.53)"
+            Assert.Equal("should match correctly", ("World", 4.53m), result)
+
+        testCase "with dashed string parts" <| fun _ ->
+            let result = sscanf "%s-%s-%s" "test-this-string"
+            Assert.Equal("should match each string correctly", ("test", "this", "string"), result)
+
+        testCase "with mixed datatypes" <| fun _ ->
+            let result = sscanf "%b-%d-%i,%u,%x,%X,%o" "false-42--31,13,ff,FF,42"
+            Assert.Equal("should parse each item correctly", (false, 42, -31, 13, 0xff, 0xFF, 0o42), result)
+
+        testCase "with mixed, space separated datatypes" <| fun _ ->
+            let result = sscanf "%f %F %g %G %e %E %c" "1 2.1 3.4 .3 43.2e32 0 f"
+            Assert.Equal("should parse each item correctly", (1., 2.1, 3.4, 0.3, 43.2e+32, 0., 'f'), result)
+        ]
+
+
+

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="HttpVerbs.fs" />
     <Compile Include="Parsing.fs" />
     <Compile Include="Perf.fs" />
+    <Compile Include="Sscanf.fs" />
     <Compile Include="Program.fs" />
     <None Include="packages.config" />
     <None Include="suave.p12">


### PR DESCRIPTION
Fix for issue SuaveIO/suave/issues/74 (sscanf bug when parsing a string contain a reserved character preceeded by %%) + created tests to cover the changes
