### PR TITLE
removed AssemblyVersionInfo.fs from .fsproj

### DIFF
--- a/Experimental/Experimental.fsproj
+++ b/Experimental/Experimental.fsproj
@@ -38,7 +38,6 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <ItemGroup>
-    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="Html.fs" />
     <Compile Include="Template.fs" />
     <Compile Include="Data.fs" />

--- a/Pong/Pong.fsproj
+++ b/Pong/Pong.fsproj
@@ -53,7 +53,6 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
     <None Include="packages.config" />

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -44,7 +44,6 @@
     <Content Include="Bug105-StopsResponding.verbose.txt" />
     <None Include="Bug105-StopsResponding.fsx" />
     <None Include="PerfLab.fsx" />
-    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="TestUtilities.fs" />
     <Compile Include="Smoke.fs" />
     <Compile Include="Utils.fs" />

--- a/suave.WebMachine/suave.WebMachine.fsproj
+++ b/suave.WebMachine/suave.WebMachine.fsproj
@@ -46,7 +46,6 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="WebMachine.fs" />
     <None Include="Script.fsx" />
     <None Include="packages.config" />


### PR DESCRIPTION
Assumed that the following was desired situation due to the list in .gitignore.  So, to
allow builds to complete without error, I
removed AssemblyVersionInfo.fs from the .fsproj for Experimental, Pong,
WebMachine, and Tests
