### PR TITLE
Adding mime type for svg images

### DIFF
--- a/Suave/Http.fs
+++ b/Suave/Http.fs
@@ -106,6 +106,7 @@ module Http =
       | ".css" -> mk_mime_type "text/css" true
       | ".gif" -> mk_mime_type "image/gif" false
       | ".png" -> mk_mime_type "image/png" false
+      | ".svg" -> mk_mime_type "image/svg+xml" false
       | ".ico" -> mk_mime_type "image/x-icon" false
       | ".htm"
       | ".html" -> mk_mime_type "text/html" true


### PR DESCRIPTION
My friend @agross had problems with svg images in FsReveal. I'm not completely sure if this is the correct fix, but I search for .png and this was the only place I found.

`image/svg+xml` is what I got from http://stackoverflow.com/questions/11918977/right-mime-type-for-svg-images-fonts
