### PR TITLE
Adjusted request headers to be type safe

### DIFF
--- a/Suave/Http.fs
+++ b/Suave/Http.fs
@@ -286,12 +286,12 @@ module Http =
     open System
     open System.Text.RegularExpressions
 
-    open Types.Methods
+    open Types
 
     let url s (x : HttpContext) = async { if s = x.request.url then return Some x else return None }
 
     let ``method`` (s : HttpMethod) (x : HttpContext) = async {
-      if s.ToString() = x.request.``method`` then return Some x else return None
+      if s = x.request.``method`` then return Some x else return None
       }
 
     let is_secure (x : HttpContext) = async {
@@ -304,15 +304,15 @@ module Http =
 
     // see http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
 
-    let GET     (x : HttpContext) = ``method`` GET x
-    let POST    (x : HttpContext) = ``method`` POST x
-    let DELETE  (x : HttpContext) = ``method`` DELETE x
-    let PUT     (x : HttpContext) = ``method`` PUT x
-    let HEAD    (x : HttpContext) = ``method`` HEAD x
-    let CONNECT (x : HttpContext) = ``method`` CONNECT x
-    let PATCH   (x : HttpContext) = ``method`` PATCH x
-    let TRACE   (x : HttpContext) = ``method`` TRACE x
-    let OPTIONS (x : HttpContext) = ``method`` OPTIONS x
+    let GET     (x : HttpContext) = ``method`` HttpMethod.GET x
+    let POST    (x : HttpContext) = ``method`` HttpMethod.POST x
+    let DELETE  (x : HttpContext) = ``method`` HttpMethod.DELETE x
+    let PUT     (x : HttpContext) = ``method`` HttpMethod.PUT x
+    let HEAD    (x : HttpContext) = ``method`` HttpMethod.HEAD x
+    let CONNECT (x : HttpContext) = ``method`` HttpMethod.CONNECT x
+    let PATCH   (x : HttpContext) = ``method`` HttpMethod.PATCH x
+    let TRACE   (x : HttpContext) = ``method`` HttpMethod.TRACE x
+    let OPTIONS (x : HttpContext) = ``method`` HttpMethod.OPTIONS x
 
     /// The default log format for <see cref="log" />.  NCSA Common log format
     /// 
@@ -337,7 +337,7 @@ module Http =
         process_id //TODO: obtain connection owner via Ident protocol
         (match Map.tryFind "user_name" ctx.user_state with Some x -> x :?> string | None -> "-")
         (DateTime.UtcNow.ToString("dd/MMM/yyyy:hh:mm:ss %K", ci))
-        ctx.request.``method``
+        (string ctx.request.``method``)
         ctx.request.url
         ctx.request.http_version
         (Codes.http_code ctx.response.status)

--- a/Suave/Http.fsi
+++ b/Suave/Http.fsi
@@ -1053,7 +1053,7 @@ module Http =
   /// Functions have signature f :: params... -> HttpContext -> HttpContext option.
   module Applicatives =
 
-    open Types.Methods
+    open Types
 
     /// Match on the url
     val url : s:string -> WebPart

--- a/Suave/Proxy.fs
+++ b/Suave/Proxy.fs
@@ -51,7 +51,7 @@ let forward (ip : IPAddress) (port : uint16) (ctx : HttpContext) =
   q.AllowAutoRedirect         <- false
   q.AllowReadStreamBuffering  <- false
   q.AllowWriteStreamBuffering <- false
-  q.Method  <- p.``method``
+  q.Method  <- string p.``method``
   q.Headers <- buildWebHeadersCollection p.headers
   q.Proxy   <- null
 
@@ -72,7 +72,7 @@ let forward (ip : IPAddress) (port : uint16) (ctx : HttpContext) =
   q.Headers.Add("X-Forwarded-For", p.ipaddr.ToString())
 
   fun ctx -> socket {
-    if p.``method`` = "POST" || p.``method`` = "PUT" then
+    if p.``method`` = HttpMethod.POST || p.``method`` = HttpMethod.PUT then
       let content_length = Convert.ToInt32(p.headers %% "content-length")
       do! transfer_len_x ctx.connection (q.GetRequestStream()) content_length
     try

--- a/Suave/Types.fs
+++ b/Suave/Types.fs
@@ -9,6 +9,180 @@ open System.Text
 
 open Socket
 
+
+
+/// <summary>
+/// <para>These are the known HTTP methods.</para><para>
+/// If you are getting compile-errors
+/// on this; make sure you don't mean the similarly named functions from the
+/// Applicatives module, e.g. by opening Applicatives after opening Http.
+/// </para></summary>
+[<RequireQualifiedAccess>]
+type HttpMethod =
+  | GET
+  | POST
+  | DELETE
+  | PUT
+  | HEAD
+  | CONNECT
+  | PATCH
+  | TRACE
+  | OPTIONS
+  | OTHER of string
+  override x.ToString() =
+    match x with
+    | GET     -> "GET"
+    | POST    -> "POST"
+    | DELETE  -> "DELETE"
+    | PUT     -> "PUT"
+    | HEAD    -> "HEAD"
+    | CONNECT -> "CONNECT"
+    | PATCH   -> "PATCH"
+    | TRACE   -> "TRACE"
+    | OPTIONS -> "OPTIONS"
+    | OTHER s -> s
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module HttpMethod =
+  let parse (str:string) =
+    match str.ToUpperInvariant() with
+      | "GET"     -> HttpMethod.GET
+      | "POST"    -> HttpMethod.POST
+      | "DELETE"  -> HttpMethod.DELETE
+      | "PUT"     -> HttpMethod.PUT
+      | "HEAD"    -> HttpMethod.HEAD
+      | "CONNECT" -> HttpMethod.CONNECT
+      | "PATCH"   -> HttpMethod.PATCH
+      | "TRACE"   -> HttpMethod.TRACE
+      | "OPTIONS" -> HttpMethod.OPTIONS
+      | s         -> HttpMethod.OTHER s
+
+module Codes =
+  type HttpCode =
+    | HTTP_100 | HTTP_101
+    | HTTP_200 | HTTP_201 | HTTP_202 | HTTP_203 | HTTP_204 | HTTP_205 | HTTP_206
+    | HTTP_300 | HTTP_301 | HTTP_302 | HTTP_303 | HTTP_304 | HTTP_305 | HTTP_307
+    | HTTP_400 | HTTP_401 | HTTP_402 | HTTP_403 | HTTP_404 | HTTP_405 | HTTP_406
+    | HTTP_407 | HTTP_408 | HTTP_409 | HTTP_410 | HTTP_411 | HTTP_412 | HTTP_413
+    | HTTP_422 | HTTP_428 | HTTP_429 | HTTP_414 | HTTP_415 | HTTP_416 | HTTP_417
+    | HTTP_500 | HTTP_501 | HTTP_502 | HTTP_503 | HTTP_504 | HTTP_505
+    static member TryParse (code : int) =
+      // TODO: replace with match code with | 100 -> HTTP_100 | ... when API is more set
+      let cases = Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<HttpCode>)
+      let map_cases =
+        cases
+        |> Array.map (fun case -> case.Name, Microsoft.FSharp.Reflection.FSharpValue.MakeUnion(case, [||]) :?> HttpCode)
+        |> Map.ofArray
+      map_cases |> Map.tryFind ("HTTP_" + code.ToString())
+
+  let http_code = function
+    | HTTP_100 -> 100 | HTTP_101 -> 101 | HTTP_200 -> 200 | HTTP_201 -> 201
+    | HTTP_202 -> 202 | HTTP_203 -> 203 | HTTP_204 -> 204 | HTTP_205 -> 205
+    | HTTP_206 -> 206 | HTTP_300 -> 300 | HTTP_301 -> 301 | HTTP_302 -> 302
+    | HTTP_303 -> 303 | HTTP_304 -> 304 | HTTP_305 -> 305 | HTTP_307 -> 307
+    | HTTP_400 -> 400 | HTTP_401 -> 401 | HTTP_402 -> 402 | HTTP_403 -> 403
+    | HTTP_404 -> 404 | HTTP_405 -> 405 | HTTP_406 -> 406 | HTTP_407 -> 407
+    | HTTP_408 -> 408 | HTTP_409 -> 409 | HTTP_410 -> 410 | HTTP_411 -> 411
+    | HTTP_412 -> 412 | HTTP_413 -> 413 | HTTP_414 -> 414 | HTTP_415 -> 415
+    | HTTP_416 -> 416 | HTTP_417 -> 417 | HTTP_422 -> 422 | HTTP_428 -> 428
+    | HTTP_429 -> 429 | HTTP_500 -> 500 | HTTP_501 -> 501 | HTTP_502 -> 502
+    | HTTP_503 -> 503 | HTTP_504 -> 504 | HTTP_505 -> 505
+
+  let http_reason = function
+    | HTTP_100 -> "Continue"
+    | HTTP_101 -> "Switching Protocols"
+    | HTTP_200 -> "OK"
+    | HTTP_201 -> "Created"
+    | HTTP_202 -> "Accepted"
+    | HTTP_203 -> "Non-Authoritative Information"
+    | HTTP_204 -> "No Content"
+    | HTTP_205 -> "Reset Content"
+    | HTTP_206 -> "Partial Content"
+    | HTTP_300 -> "Multiple Choices"
+    | HTTP_301 -> "Moved Permanently"
+    | HTTP_302 -> "Found"
+    | HTTP_303 -> "See Other"
+    | HTTP_304 -> "Not Modified"
+    | HTTP_305 -> "Use Proxy"
+    | HTTP_307 -> "Temporary Redirect"
+    | HTTP_400 -> "Bad Request"
+    | HTTP_401 -> "Unauthorized"
+    | HTTP_402 -> "Payment Required"
+    | HTTP_403 -> "Forbidden"
+    | HTTP_404 -> "Not Found"
+    | HTTP_405 -> "Method Not Allowed"
+    | HTTP_406 -> "Not Acceptable"
+    | HTTP_407 -> "Proxy Authentication Required"
+    | HTTP_408 -> "Request Timeout"
+    | HTTP_409 -> "Conflict"
+    | HTTP_410 -> "Gone"
+    | HTTP_411 -> "Length Required"
+    | HTTP_412 -> "Precondition Failed"
+    | HTTP_413 -> "Request Entity Too Large"
+    | HTTP_414 -> "Request-URI Too Long"
+    | HTTP_415 -> "Unsupported Media Type"
+    | HTTP_416 -> "Requested Range Not Satisfiable"
+    | HTTP_417 -> "Expectation Failed"
+    | HTTP_422 -> "Unprocessable Entity"
+    | HTTP_428 -> "Precondition Required"
+    | HTTP_429 -> "Too Many Requests"
+    | HTTP_500 -> "Internal Server Error"
+    | HTTP_501 -> "Not Implemented"
+    | HTTP_502 -> "Bad Gateway"
+    | HTTP_503 -> "Service Unavailable"
+    | HTTP_504 -> "Gateway Timeout"
+    | HTTP_505 -> "HTTP Version Not Supported"
+
+  let http_message = function
+    | HTTP_100 -> "Request received, please continue"
+    | HTTP_101 -> "Switching to new protocol; obey Upgrade header"
+    | HTTP_200 -> "Request fulfilled, document follows"
+    | HTTP_201 -> "Document created, URL follows"
+    | HTTP_202 -> "Request accepted, processing continues off-line"
+    | HTTP_203 -> "Request fulfilled from cache"
+    | HTTP_204 -> "Request fulfilled, nothing follows"
+    | HTTP_205 -> "Clear input form for further input."
+    | HTTP_206 -> "Partial content follows."
+    | HTTP_300 -> "Object has several resources -- see URI list"
+    | HTTP_301 -> "Object moved permanently -- see URI list"
+    | HTTP_302 -> "Object moved temporarily -- see URI list"
+    | HTTP_303 -> "Object moved -- see Method and URL list"
+    | HTTP_304 -> "Document has not changed since given time"
+    | HTTP_305 -> "You must use proxy specified in Location to access this resource."
+    | HTTP_307 -> "Object moved temporarily -- see URI list"
+    | HTTP_400 -> "Bad request syntax or unsupported method"
+    | HTTP_401 -> "No permission -- see authorization schemes"
+    | HTTP_402 -> "No payment -- see charging schemes"
+    | HTTP_403 -> "Request forbidden -- authorization will not help"
+    | HTTP_404 -> "Nothing matches the given URI"
+    | HTTP_405 -> "Specified method is invalid for this resource."
+    | HTTP_406 -> "URI not available in preferred format."
+    | HTTP_407 -> "You must authenticate with this proxy before proceeding."
+    | HTTP_408 -> "Request timed out; try again later."
+    | HTTP_409 -> "Request conflict."
+    | HTTP_410 -> "URI no longer exists and has been permanently removed."
+    | HTTP_411 -> "Client must specify Content-Length."
+    | HTTP_412 -> "Precondition in headers is false."
+    | HTTP_413 -> "Entity is too large."
+    | HTTP_414 -> "URI is too long."
+    | HTTP_415 -> "Entity body in unsupported format."
+    | HTTP_416 -> "Cannot satisfy request range."
+    | HTTP_417 -> "Expect condition could not be satisfied."
+    | HTTP_422 -> "The entity sent to the server was invalid."
+    | HTTP_428 -> "You should verify the server accepts the request before sending it."
+    | HTTP_429 -> "Request rate too high, chill out please."
+    | HTTP_500 -> "Server got itself in trouble"
+    | HTTP_501 -> "Server does not support this operation"
+    | HTTP_502 -> "Invalid responses from another server/proxy."
+    | HTTP_503 -> "The server cannot process the request due to a high load"
+    | HTTP_504 -> "The gateway server did not receive a timely response"
+    | HTTP_505 -> "Cannot fulfill request."
+
+  type HttpCode with
+    member x.Describe () =
+      sprintf "%d %s: %s" (http_code x) (http_reason x) (http_message x)
+
+
 /// HTTP cookie
 type HttpCookie =
   { name      : string
@@ -128,7 +302,7 @@ module HttpUpload =
 type HttpRequest =
   { http_version     : string
     url              : string
-    ``method``       : string
+    ``method``       : HttpMethod
     headers          : (string * string) list
     raw_form         : byte []
     raw_query        : string
@@ -146,7 +320,7 @@ module HttpRequest =
   let empty =
     { http_version     = "1.1"
       url              = "/"
-      ``method``       = ""
+      ``method``       = HttpMethod.OTHER("")
       headers          = []
       raw_form         = Array.empty
       raw_query        = ""
@@ -284,160 +458,6 @@ type HttpContent =
   | NullContent
   | Bytes of byte []
   | SocketTask of (Connection -> SocketOp<unit>)
-
-/// <summary>
-/// <para>These are the known HTTP methods.</para><para>
-/// If you are getting compile-errors
-/// on this; make sure you don't mean the similarly named functions from the
-/// Applicatives module, e.g. by opening Applicatives after opening Http.
-/// </para></summary>
-module Methods =
-  type HttpMethod =
-    | GET
-    | POST
-    | DELETE
-    | PUT
-    | HEAD
-    | CONNECT
-    | PATCH
-    | TRACE
-    | OPTIONS
-    override x.ToString() =
-      match x with
-      | GET     -> "GET"
-      | POST    -> "POST"
-      | DELETE  -> "DELETE"
-      | PUT     -> "PUT"
-      | HEAD    -> "HEAD"
-      | CONNECT -> "CONNECT"
-      | PATCH   -> "PATCH"
-      | TRACE   -> "TRACE"
-      | OPTIONS -> "OPTIONS"
-
-module Codes =
-  type HttpCode =
-    | HTTP_100 | HTTP_101
-    | HTTP_200 | HTTP_201 | HTTP_202 | HTTP_203 | HTTP_204 | HTTP_205 | HTTP_206
-    | HTTP_300 | HTTP_301 | HTTP_302 | HTTP_303 | HTTP_304 | HTTP_305 | HTTP_307
-    | HTTP_400 | HTTP_401 | HTTP_402 | HTTP_403 | HTTP_404 | HTTP_405 | HTTP_406
-    | HTTP_407 | HTTP_408 | HTTP_409 | HTTP_410 | HTTP_411 | HTTP_412 | HTTP_413
-    | HTTP_422 | HTTP_428 | HTTP_429 | HTTP_414 | HTTP_415 | HTTP_416 | HTTP_417
-    | HTTP_500 | HTTP_501 | HTTP_502 | HTTP_503 | HTTP_504 | HTTP_505
-    static member TryParse (code : int) =
-      // TODO: replace with match code with | 100 -> HTTP_100 | ... when API is more set
-      let cases = Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<HttpCode>)
-      let map_cases =
-        cases
-        |> Array.map (fun case -> case.Name, Microsoft.FSharp.Reflection.FSharpValue.MakeUnion(case, [||]) :?> HttpCode)
-        |> Map.ofArray
-      map_cases |> Map.tryFind ("HTTP_" + code.ToString())
-
-  let http_code = function
-    | HTTP_100 -> 100 | HTTP_101 -> 101 | HTTP_200 -> 200 | HTTP_201 -> 201
-    | HTTP_202 -> 202 | HTTP_203 -> 203 | HTTP_204 -> 204 | HTTP_205 -> 205
-    | HTTP_206 -> 206 | HTTP_300 -> 300 | HTTP_301 -> 301 | HTTP_302 -> 302
-    | HTTP_303 -> 303 | HTTP_304 -> 304 | HTTP_305 -> 305 | HTTP_307 -> 307
-    | HTTP_400 -> 400 | HTTP_401 -> 401 | HTTP_402 -> 402 | HTTP_403 -> 403
-    | HTTP_404 -> 404 | HTTP_405 -> 405 | HTTP_406 -> 406 | HTTP_407 -> 407
-    | HTTP_408 -> 408 | HTTP_409 -> 409 | HTTP_410 -> 410 | HTTP_411 -> 411
-    | HTTP_412 -> 412 | HTTP_413 -> 413 | HTTP_414 -> 414 | HTTP_415 -> 415
-    | HTTP_416 -> 416 | HTTP_417 -> 417 | HTTP_422 -> 422 | HTTP_428 -> 428
-    | HTTP_429 -> 429 | HTTP_500 -> 500 | HTTP_501 -> 501 | HTTP_502 -> 502
-    | HTTP_503 -> 503 | HTTP_504 -> 504 | HTTP_505 -> 505
-
-  let http_reason = function
-    | HTTP_100 -> "Continue"
-    | HTTP_101 -> "Switching Protocols"
-    | HTTP_200 -> "OK"
-    | HTTP_201 -> "Created"
-    | HTTP_202 -> "Accepted"
-    | HTTP_203 -> "Non-Authoritative Information"
-    | HTTP_204 -> "No Content"
-    | HTTP_205 -> "Reset Content"
-    | HTTP_206 -> "Partial Content"
-    | HTTP_300 -> "Multiple Choices"
-    | HTTP_301 -> "Moved Permanently"
-    | HTTP_302 -> "Found"
-    | HTTP_303 -> "See Other"
-    | HTTP_304 -> "Not Modified"
-    | HTTP_305 -> "Use Proxy"
-    | HTTP_307 -> "Temporary Redirect"
-    | HTTP_400 -> "Bad Request"
-    | HTTP_401 -> "Unauthorized"
-    | HTTP_402 -> "Payment Required"
-    | HTTP_403 -> "Forbidden"
-    | HTTP_404 -> "Not Found"
-    | HTTP_405 -> "Method Not Allowed"
-    | HTTP_406 -> "Not Acceptable"
-    | HTTP_407 -> "Proxy Authentication Required"
-    | HTTP_408 -> "Request Timeout"
-    | HTTP_409 -> "Conflict"
-    | HTTP_410 -> "Gone"
-    | HTTP_411 -> "Length Required"
-    | HTTP_412 -> "Precondition Failed"
-    | HTTP_413 -> "Request Entity Too Large"
-    | HTTP_414 -> "Request-URI Too Long"
-    | HTTP_415 -> "Unsupported Media Type"
-    | HTTP_416 -> "Requested Range Not Satisfiable"
-    | HTTP_417 -> "Expectation Failed"
-    | HTTP_422 -> "Unprocessable Entity"
-    | HTTP_428 -> "Precondition Required"
-    | HTTP_429 -> "Too Many Requests"
-    | HTTP_500 -> "Internal Server Error"
-    | HTTP_501 -> "Not Implemented"
-    | HTTP_502 -> "Bad Gateway"
-    | HTTP_503 -> "Service Unavailable"
-    | HTTP_504 -> "Gateway Timeout"
-    | HTTP_505 -> "HTTP Version Not Supported"
-
-  let http_message = function
-    | HTTP_100 -> "Request received, please continue"
-    | HTTP_101 -> "Switching to new protocol; obey Upgrade header"
-    | HTTP_200 -> "Request fulfilled, document follows"
-    | HTTP_201 -> "Document created, URL follows"
-    | HTTP_202 -> "Request accepted, processing continues off-line"
-    | HTTP_203 -> "Request fulfilled from cache"
-    | HTTP_204 -> "Request fulfilled, nothing follows"
-    | HTTP_205 -> "Clear input form for further input."
-    | HTTP_206 -> "Partial content follows."
-    | HTTP_300 -> "Object has several resources -- see URI list"
-    | HTTP_301 -> "Object moved permanently -- see URI list"
-    | HTTP_302 -> "Object moved temporarily -- see URI list"
-    | HTTP_303 -> "Object moved -- see Method and URL list"
-    | HTTP_304 -> "Document has not changed since given time"
-    | HTTP_305 -> "You must use proxy specified in Location to access this resource."
-    | HTTP_307 -> "Object moved temporarily -- see URI list"
-    | HTTP_400 -> "Bad request syntax or unsupported method"
-    | HTTP_401 -> "No permission -- see authorization schemes"
-    | HTTP_402 -> "No payment -- see charging schemes"
-    | HTTP_403 -> "Request forbidden -- authorization will not help"
-    | HTTP_404 -> "Nothing matches the given URI"
-    | HTTP_405 -> "Specified method is invalid for this resource."
-    | HTTP_406 -> "URI not available in preferred format."
-    | HTTP_407 -> "You must authenticate with this proxy before proceeding."
-    | HTTP_408 -> "Request timed out; try again later."
-    | HTTP_409 -> "Request conflict."
-    | HTTP_410 -> "URI no longer exists and has been permanently removed."
-    | HTTP_411 -> "Client must specify Content-Length."
-    | HTTP_412 -> "Precondition in headers is false."
-    | HTTP_413 -> "Entity is too large."
-    | HTTP_414 -> "URI is too long."
-    | HTTP_415 -> "Entity body in unsupported format."
-    | HTTP_416 -> "Cannot satisfy request range."
-    | HTTP_417 -> "Expect condition could not be satisfied."
-    | HTTP_422 -> "The entity sent to the server was invalid."
-    | HTTP_428 -> "You should verify the server accepts the request before sending it."
-    | HTTP_429 -> "Request rate too high, chill out please."
-    | HTTP_500 -> "Server got itself in trouble"
-    | HTTP_501 -> "Server does not support this operation"
-    | HTTP_502 -> "Invalid responses from another server/proxy."
-    | HTTP_503 -> "The server cannot process the request due to a high load"
-    | HTTP_504 -> "The gateway server did not receive a timely response"
-    | HTTP_505 -> "Cannot fulfill request."
-
-  type HttpCode with
-    member x.Describe () =
-      sprintf "%d %s: %s" (http_code x) (http_reason x) (http_message x)
 
 open Codes
 

--- a/Suave/Web.fs
+++ b/Suave/Web.fs
@@ -281,7 +281,8 @@ module ParsingAndControl =
 
     let! (first_line : string), connection = read_line ctx.connection
 
-    let meth, url, raw_query, http_version = parse_url first_line
+    let raw_method, url, raw_query, http_version = parse_url first_line
+    let meth = HttpMethod.parse raw_method
 
     let! headers, connection = read_headers connection
 

--- a/Tests/HttpEmbedded.fs
+++ b/Tests/HttpEmbedded.fs
@@ -3,7 +3,7 @@
 open Fuchu
 
 open Suave
-open Suave.Types.Methods
+open Suave.Types
 open Suave.Http
 open Suave.Http.Successful
 open Suave.Http.Embedded
@@ -16,5 +16,5 @@ let embedded_resources =
 
   testList "test Embedded.browse" [
       testCase "200 OK returns embedded file" <| fun _ ->
-        Assert.Equal("expecting 'Hello World!'", "Hello World!", run_with' browse' |> req GET "/embedded-resource.txt" None)
+        Assert.Equal("expecting 'Hello World!'", "Hello World!", run_with' browse' |> req HttpMethod.GET "/embedded-resource.txt" None)
     ]

--- a/Tests/HttpFile.fs
+++ b/Tests/HttpFile.fs
@@ -6,7 +6,7 @@ open System
 open System.IO
 open System.Text
 
-open Suave.Types.Methods
+open Suave.Types
 open Suave.Http
 open Suave.Http.Successful
 open Suave.Tests.TestUtilities
@@ -28,18 +28,18 @@ let compression =
 
   testList "getting basic gzip/deflate responses" [
       testCase "200 OK returns 'Havana' with gzip " <| fun _ ->
-        Assert.Equal("expecting 'Havana'", "Havana", run_with' (OK "Havana") |> req_gzip GET "/" None)
+        Assert.Equal("expecting 'Havana'", "Havana", run_with' (OK "Havana") |> req_gzip HttpMethod.GET "/" None)
 
       testCase "200 OK returns 'Havana' with deflate " <| fun _ ->
-        Assert.Equal("expecting 'Havana'", "Havana", run_with' (OK "Havana") |> req_deflate GET "/" None)
+        Assert.Equal("expecting 'Havana'", "Havana", run_with' (OK "Havana") |> req_deflate HttpMethod.GET "/" None)
 
       testCase "verifiying we get the same size uncompressed" <| fun _ ->
         Assert.Equal("length should match"
         , test_file_size
-        , (run_with' (Files.browse_file' "test-text-file.txt") |> req_bytes GET "/" None).Length |> int64)
+        , (run_with' (Files.browse_file' "test-text-file.txt") |> req_bytes HttpMethod.GET "/" None).Length |> int64)
 
       testCase "gzip static file" <| fun _ ->
         Assert.Equal("length should match"
         , test_file_size
-        , (run_with' (Files.browse_file' "test-text-file.txt") |> req_gzip_bytes GET "/" None).Length |> int64)
+        , (run_with' (Files.browse_file' "test-text-file.txt") |> req_gzip_bytes HttpMethod.GET "/" None).Length |> int64)
     ]

--- a/Tests/HttpVerbs.fs
+++ b/Tests/HttpVerbs.fs
@@ -6,7 +6,7 @@ open System.Net.Http
 
 open Suave
 open Suave.Types
-open Suave.Types.Methods
+open Suave.Types
 open Suave.Web
 open Suave.Http
 open Successful
@@ -20,17 +20,17 @@ let gets =
   let run_with' = run_with default_config
   testList "getting basic responses" [
       testCase "200 OK returns 'a'" <| fun _ ->
-        Assert.Equal("expecting non-empty response", "a", run_with' (OK "a") |> req GET "/" None)
+        Assert.Equal("expecting non-empty response", "a", run_with' (OK "a") |> req HttpMethod.GET "/" None)
 
       testPropertyWithConfig fscheck_config "200 OK returns equivalent" <| fun resp_str ->
-        (run_with' (OK resp_str) |> req GET "/hello" None) = resp_str
+        (run_with' (OK resp_str) |> req HttpMethod.GET "/hello" None) = resp_str
 
       testCase "204 No Content empty body" <| fun _ ->
         Assert.Equal("empty string should always be returned by 204 No Content",
-                     "", (run_with' NO_CONTENT |> req GET "/" None))
+                     "", (run_with' NO_CONTENT |> req HttpMethod.GET "/" None))
 
       testCase "302 FOUND sends content-length header" <| fun _ ->
-        let headers = req_content_headers GET "/" None (run_with' (Redirection.FOUND "/url"))
+        let headers = req_content_headers HttpMethod.GET "/" None (run_with' (Redirection.FOUND "/url"))
         Assert.Equal("302 FOUND sends content-length header",
                      true,
                      headers.Contains("Content-Length"))
@@ -86,17 +86,17 @@ let posts =
   testList "posting basic data" [
       testCase "POST data round trips with no content-type" <| fun _ ->
         use data = new StringContent("bob")
-        Assert.Equal("expecting data to be returned", "bob", run_with' webId |> req POST "/" (Some data))
+        Assert.Equal("expecting data to be returned", "bob", run_with' webId |> req HttpMethod.POST "/" (Some data))
       testCase "POST form data makes round trip" <| fun _ ->
         use data = new FormUrlEncodedContent(dict [ "name", "bob"])
-        Assert.Equal("expecting form data to be returned", "bob", run_with' (getFormValue "name") |> req POST "/" (Some data))
+        Assert.Equal("expecting form data to be returned", "bob", run_with' (getFormValue "name") |> req HttpMethod.POST "/" (Some data))
       testCase "POST long data" <| fun _ ->
         use data = new FormUrlEncodedContent(dict [ "long", longData])
-        Assert.Equal("expecting form data to be returned", longData, run_with' (getFormValue "long") |> req POST "/" (Some data))
+        Assert.Equal("expecting form data to be returned", longData, run_with' (getFormValue "long") |> req HttpMethod.POST "/" (Some data))
       testCase "POST persona assertion" <| fun _ ->
         use data = new FormUrlEncodedContent(dict [ "assertion", assertion])
-        Assert.Equal("expecting form data to be returned", assertion, run_with' (getFormValue "assertion") |> req POST "/" (Some data))
+        Assert.Equal("expecting form data to be returned", assertion, run_with' (getFormValue "assertion") |> req HttpMethod.POST "/" (Some data))
       testCase "POST unicode data" <| fun _ ->
         use data = new FormUrlEncodedContent(dict [ "name", unicodeString ])
-        Assert.Equal("expecting form data to be returned", unicodeString, run_with' (getFormValue "name") |> req POST "/" (Some data))
+        Assert.Equal("expecting form data to be returned", unicodeString, run_with' (getFormValue "name") |> req HttpMethod.POST "/" (Some data))
     ]

--- a/Tests/HttpWriters.fs
+++ b/Tests/HttpWriters.fs
@@ -9,7 +9,6 @@ open Suave.Http
 open Suave.Http.Successful
 open Suave.Http.Writers
 open Suave.Types
-open Suave.Types.Methods
 
 open Suave.Tests.TestUtilities
 
@@ -30,21 +29,21 @@ let cookies =
       testCase "cookie data makes round trip" <| fun _ ->
         Assert.Equal("expecting cookie value"
         , "42"
-        , (req_cookies GET "/" None
+        , (req_cookies HttpMethod.GET "/" None
           (run_with' (Cookie.set_cookie basic_cookie >>= OK "test")))
             .GetCookies(Uri("http://127.0.0.1")).[0].Value)
 
       testCase "cookie name makes round trip" <| fun _ ->
         Assert.Equal("expecting cookie name"
         , "mycookie"
-        , (req_cookies GET "/" None
+        , (req_cookies HttpMethod.GET "/" None
             (run_with' (Cookie.set_cookie basic_cookie >>= OK "test")))
             .GetCookies(Uri("http://127.0.0.1")).[0].Name)
 
       testCase "http_only cookie is http_only" <| fun _ ->
         Assert.Equal("expecting http_only"
         , true
-        , (req_cookies GET "/" None
+        , (req_cookies HttpMethod.GET "/" None
           (run_with' (Cookie.set_cookie { basic_cookie with http_only = true } >>= OK "test")))
             .GetCookies(Uri("http://127.0.0.1")).[0].HttpOnly)
     ]

--- a/Tests/Json.fs
+++ b/Tests/Json.fs
@@ -9,7 +9,6 @@ open System.Net.Http.Headers
 open System.Text
 
 open Suave
-open Suave.Types.Methods
 open Suave.Types
 open Suave.Http
 open Suave.Json
@@ -38,5 +37,5 @@ let parsing_multipart =
   testList "map_json test" [
     testCase "simple test" <| fun _ ->
       Assert.Equal("returns correct json representation", "{\"bar\":\"foo\"}", 
-        run_with' (map_json (fun (a:Foo) -> { bar = a.foo })) |> req POST "/" (Some <| new ByteArrayContent(to_json { foo = "foo" }))) ]
+        run_with' (map_json (fun (a:Foo) -> { bar = a.foo })) |> req HttpMethod.POST "/" (Some <| new ByteArrayContent(to_json { foo = "foo" }))) ]
 

--- a/Tests/Model.fs
+++ b/Tests/Model.fs
@@ -10,7 +10,7 @@ open Fuchu
 open Suave
 open Suave.Types
 open Suave.Model
-open Suave.Types.Methods
+open Suave.Types
 open Suave.Http
 open Suave.Http.Successful
 open Suave.Http.RequestErrors
@@ -47,12 +47,12 @@ let tests =
         "should have read data",
         "identifier 123abc",
         run_with' (test_url_encoded_form "body-plain")
-        |> req_gzip POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
+        |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
     testCase "200 OK returns 'a'" <| fun _ ->
       Assert.Equal(
         "expecting nilsson response",
         "nilsson",
         run_with' (Binding.bind_req (Binding.query "apa" Choice1Of2) OK BAD_REQUEST)
-        |> req_query GET "/" "apa=nilsson")
+        |> req_query HttpMethod.GET "/" "apa=nilsson")
     ]

--- a/Tests/Parsing.fs
+++ b/Tests/Parsing.fs
@@ -9,7 +9,7 @@ open System.Net.Http.Headers
 open System.Text
 
 open Suave
-open Suave.Types.Methods
+open Suave.Types
 open Suave.Types
 open Suave.Http
 open Suave.Http.Successful
@@ -43,25 +43,25 @@ let parsing_multipart =
 
   testList "http parser tests" [
       testCase "parsing a large multipart form" <| fun _ ->
-        Assert.Equal("", "Bob <bob@wishfulcoding.mailgun.org>", run_with' test_multipart_form |> req POST "/" (Some <| byte_array_content))
+        Assert.Equal("", "Bob <bob@wishfulcoding.mailgun.org>", run_with' test_multipart_form |> req HttpMethod.POST "/" (Some <| byte_array_content))
 
       testCase "parsing a large urlencoded form data" <| fun _ ->
         Assert.Equal("", "hallo wereld", 
-          run_with' (test_url_encoded_form "stripped-text") |> req_gzip POST "/" (Some <| new StringContent(post_data2, Encoding.UTF8, "application/x-www-form-urlencoded")))
+          run_with' (test_url_encoded_form "stripped-text") |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data2, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
       testCase "parsing a large urlencoded form data" <| fun _ ->
         Assert.Equal("", "Pepijn de Vos <pepijndevos@gmail.com>", 
-          run_with' (test_url_encoded_form "from") |> req_gzip POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
+          run_with' (test_url_encoded_form "from") |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
       testCase "parsing a large urlencoded form data" <| fun _ ->
         Assert.Equal("", "no attachment 2", 
-          run_with' (test_url_encoded_form "subject") |> req_gzip POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
+          run_with' (test_url_encoded_form "subject") |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
       testCase "parsing a large urlencoded form data" <| fun _ ->
         Assert.Equal("", "identifier 123abc", 
-          run_with' (test_url_encoded_form "body-plain") |> req_gzip POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
+          run_with' (test_url_encoded_form "body-plain") |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
       testCase "parsing a large urlencoded form data" <| fun _ ->
         Assert.Equal("", "field-does-not-exists", 
-          run_with' (test_url_encoded_form "body-html") |> req_gzip POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
+          run_with' (test_url_encoded_form "body-html") |> req_gzip HttpMethod.POST "/" (Some <| new StringContent(post_data3, Encoding.UTF8, "application/x-www-form-urlencoded")))
   ]

--- a/Tests/Perf.fs
+++ b/Tests/Perf.fs
@@ -2,7 +2,6 @@
 
 open Suave.Utils
 open Suave.Types
-open Suave.Types.Methods
 open Suave.Http
 open Suave.Http.Successful
 open Suave.Web
@@ -46,7 +45,7 @@ let perf_tests =
   testList "performance tests" [
     testPerfHistory "perf-GET" server_factory version [
       perfTest "GET /" <| fun harness ->
-        iterate 400 (fun _ -> harness.Serve (OK "a") |> req GET "/" None |> ignore)
+        iterate 400 (fun _ -> harness.Serve (OK "a") |> req HttpMethod.GET "/" None |> ignore)
       ]
 
     testPerfHistory "perf-POST" server_factory version [
@@ -55,6 +54,6 @@ let perf_tests =
           use data = new FormUrlEncodedContent(dict ["long", longData])
           Assert.Equal("expecting form data to be returned",
                        longData,
-                       harness.Serve (getFormValue "long") |> req POST "/" (Some data)))
+                       harness.Serve (getFormValue "long") |> req HttpMethod.POST "/" (Some data)))
       ]
     ]

--- a/Tests/Proxy.fs
+++ b/Tests/Proxy.fs
@@ -12,7 +12,6 @@ open System.Net
 
 open Suave
 open Suave.Types
-open Suave.Types.Methods
 open Suave.Http.Successful
 open Suave.Http.Redirection
 open Suave.Http.ServerErrors

--- a/Tests/TestUtilities.fs
+++ b/Tests/TestUtilities.fs
@@ -12,7 +12,6 @@ open System.Reflection
 
 open Suave
 open Suave.Types
-open Suave.Types.Methods
 open Suave.Web
 open Suave.Http
 open Suave.Log


### PR DESCRIPTION
Currently, `HttpRequest`'s `method` field is not strongly typed. Instead, they're handled as strings internally.
This patch provides strong type safety for the possible methods, as well as handling the case of an unexpected method explicitly.

It also fixes the issue mentioned in the comment by requiring fully qualified access to the well typed names:

```
/// If you are getting compile-errors
/// on this; make sure you don't mean the similarly named functions from the
/// Applicatives module, e.g. by opening Applicatives after opening Http.
```

While the qualified access is a breaking API change, any client-side adjustments should be very minor outside of the Unit Testing.
