### PR TITLE
Open in Visual Studio 2013 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ miTLS/
 Backup/
 paket.exe
 !paket.lock
+**.suo

--- a/src/Suave.sln
+++ b/src/Suave.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{F0556ECB-F98B-4072-8A79-F02C3862138D}"
 	ProjectSection(SolutionItems) = preProject
 		..\paket.dependencies = ..\paket.dependencies


### PR DESCRIPTION
1) If you have both VS 2012 and VS 2013 installed you'd probably rather use 2013
2) If it does open in 2012 then it fails to build, because VS 2012 uses F# 3.0 by default, and the project files don't explicitly state 3.1 as a dependency