### PR TITLE
Remove gratuitous "<|"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ testCase "parsing a large multipart form" <| fun _ ->
 
   let res =
     run_with' (OK "hi")
-    |> req HttpMethod.POST "/" (Some <| byte_array_content)
+    |> req HttpMethod.POST "/" (Some byte_array_content)
 
   Assert.Equal("should get the correct result", "hi", res)
 ```


### PR DESCRIPTION
I only recommend the use of "<|" in limited circumstances in F# code. I particularly don't like using it just to remove parentheses on a single line (especially in nested expression positions), since it makes F# code considerably harder to read, especially for newcomers.

My personal recommendation is to only use "<|" when declaring a function "block" for the final parameter to a combinator as in 

``
testCase "xyz" <| fun _ -> 
    ...
``

And even then I think you should be very restrained - for example, it is probably better not to use it in any tutorial, book or beginner code.

I know opinions vary on these things, I'm just giving my preferred position for the F# language here.

Cheers & thanks!
Don Syme