### PR TITLE
add heroku instructions

### DIFF
--- a/_includes/content.md
+++ b/_includes/content.md
@@ -594,3 +594,51 @@ let webConfig =
       logger   = SuaveAdapter(logary.GetLogger "suave")
   }
 {% endhighlight %}
+
+Deploying Suave to Heroku
+----------------------------
+
+1. [Install the Heroku Toolbelt](https://toolbelt.heroku.com/)
+
+2. Login to Heroku and push your project:
+
+{% highlight bash %}
+heroku login
+{% endhighlight %}
+
+3. Your application needs to be either
+
+   - a single script app.fsx (plus an heroku Procfile and dummy.sln file) OR 
+   - a directory with a .sln solution
+	
+   Optionally, you can have a paket.dependencies OR packages.config files
+
+   If using an app.fsx then it must start a web server that binds to 0.0.0.0:$PORT.
+   
+If you don't have an app.fsx already that implements your website, then clone an example, putting it in a new directory (replace myproj by a unique project name)
+
+{% highlight bash %}
+git clone https://github.com/dsyme/heroku-getting-started.git -d myproj
+cd myproj
+{% endhighlight %}
+
+4. Create a new heroku web app and register "heroku" as a remote you can push to:
+
+{% highlight bash %}
+heroku create myproj --buildpack https://github.com/dsyme/mono-script-buildpack.git 
+heroku git:remote -a myproj
+{% endhighlight %}
+
+5. Push!
+
+Use an empty user name. You may need to use ``git auth:token`` to get a app token to use as a password here.
+
+{% highlight bash %}
+git push heroku master  
+{% endhighlight %}
+
+
+- If using github or bitbucket, find your app on Heroku and enable automatic deploy so you don't need to push explciitly.
+
+- You can look at logs from your web server script using ``heroku logs``.
+


### PR DESCRIPTION
This adds some instructions for using Suave + F# + Heroku.

* Please check them after merging.  

* The two "dsyme" repositories should I think be moved into https://github.com/SuaveIO to make all information related to Suave self-contained.  If you just clone them across and adjust the docs that would be great.

* The Mono 3.0 being used is the one originally used by https://github.com/aktowns/mono3-buildpack.  This was built by that person from an earlier version of Mono 3 with prefix ``app/vendor/mono3``.  We really need to be getting a ZIP-installable builds of later, up-to-date, build of Mono+F# from somewhere else - ideally mono-project.com would include these.

The instructions to use other hosting providers will be similar I suppose; most of them seem to follow a buildpack model.
