### PR TITLE
Fix Suave + Paket = ♥ example

### DIFF
--- a/_includes/content.md
+++ b/_includes/content.md
@@ -75,8 +75,8 @@ open System.IO
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
  
 if not (File.Exists "paket.exe") then
-let url = "https://github.com/fsprojects/Paket/releases/download/0.31.5/paket.exe"
-use wc = new Net.WebClient() in let tmp = Path.GetTempFileName() in wc.DownloadFile(url, tmp); File.Move(tmp,Path.GetFileName url)
+    let url = "https://github.com/fsprojects/Paket/releases/download/0.31.5/paket.exe"
+    use wc = new Net.WebClient() in let tmp = Path.GetTempFileName() in wc.DownloadFile(url, tmp); File.Move(tmp,Path.GetFileName url)
  
 // Step 1. Resolve and install the packages
  


### PR DESCRIPTION
Indent the 2 lines after the `if not (File.Exists "paket.exe") then`

The example does not work without the indentation when pasted into a new script