### PR TITLE
Adding indexed property in http request to get form values like that of in ASP.NET web pages

### DIFF
--- a/src/Suave.Tests/Types.fs
+++ b/src/Suave.Tests/Types.fs
@@ -7,6 +7,8 @@ open Fuchu
 
 open Suave.Sockets
 open Suave.Types
+open System.Net.Http
+open Suave.Testing
 
 [<Tests>]
 let socket_binding =
@@ -49,3 +51,21 @@ let http_binding =
       Assert.Equal("uri", "http://127.0.0.1/",
                    binding.uri "/" "" |> sprintf "%O")
     ]
+
+
+[<Tests>]
+let http_request_indexed_property =
+
+  let createReq (data : FormUrlEncodedContent) = 
+    {HttpRequest.empty with rawForm = data.ReadAsByteArrayAsync().Result}
+
+  testList "Http Request Index Property for retrieving form data" [
+    testCase "get form value for the given key" <| fun _ ->
+      use data = new FormUrlEncodedContent(dict [ "name", "bob"])
+      let req = createReq data
+      Assert.Equal("form data ", Some "bob", req.["name"])
+    testCase "get form value for a key which is absent" <| fun _ ->
+      use data = new FormUrlEncodedContent(dict [ "name", "bob"])
+      let req = createReq data
+      Assert.Equal("form data ", None, req.["age"])
+  ]

--- a/src/Suave.Tests/Types.fs
+++ b/src/Suave.Tests/Types.fs
@@ -54,12 +54,12 @@ let http_binding =
 
 
 [<Tests>]
-let http_request_indexed_property =
+let http_request_indexed_property_form_data =
 
   let createReq (data : FormUrlEncodedContent) = 
     {HttpRequest.empty with rawForm = data.ReadAsByteArrayAsync().Result}
 
-  testList "Http Request Index Property for retrieving form data" [
+  testList "Http Request Index Property for retrieving Form data" [
     testCase "get form value for the given key" <| fun _ ->
       use data = new FormUrlEncodedContent(dict [ "name", "bob"])
       let req = createReq data
@@ -68,4 +68,38 @@ let http_request_indexed_property =
       use data = new FormUrlEncodedContent(dict [ "name", "bob"])
       let req = createReq data
       Assert.Equal("form data ", None, req.["age"])
+  ]
+  
+[<Tests>]
+let http_request_indexed_property_query_string_data =
+
+  let createReq rawQuery = 
+    {HttpRequest.empty with rawQuery = rawQuery}
+
+  testList "Http Request Index Property for retrieving query string data" [
+    testCase "get query string value for the given key" <| fun _ ->
+      let req1 = createReq "name=bob"
+      let req2 = createReq "name=bob&age=24"
+      Assert.Equal("query string data ", Some "bob", req1.["name"])
+      Assert.Equal("query string data ", Some "24", req2.["age"])
+    testCase "get query string value for a key which is absent" <| fun _ ->
+      let req1 = createReq ""
+      let req2 = createReq "name=bob"
+      Assert.Equal("query string data ", None, req1.["age"])
+      Assert.Equal("query string data ", None, req2.["age"])
+  ]
+
+[<Tests>]
+let http_request_indexed_property_multi_part_fields_data =
+
+  let createReq multiPartFields = 
+    {HttpRequest.empty with multiPartFields = multiPartFields}
+
+  testList "Http Request Index Property for retrieving multi part fields data" [
+    testCase "get multi part fields value for the given key" <| fun _ ->
+      let req = createReq [("name", "bob")]
+      Assert.Equal("multi part fields data ", Some "bob", req.["name"])
+    testCase "get multi part fields value for a key which is absent" <| fun _ ->
+      let req = createReq [("name", "bob")]
+      Assert.Equal("multi part fields data ", None, req.["age"])
   ]

--- a/src/Suave/Types.fs
+++ b/src/Suave/Types.fs
@@ -357,13 +357,22 @@ type HttpRequest =
     getFirstOpt x.form k
 
 
-  /// Syntatic Sugar to retrieve form values from HttpRequest like in Asp.Net Web Pages  
-  member this.Item 
-    with get(x) = 
-      match this.formData x with
-      | Choice1Of2 str -> Some str
-      | Choice2Of2 _ -> None
+  /// Syntactic Sugar to retrieve query string, form or multi-field values from HttpRequest 
+  member this.Item     
+    with get(x) =    
 
+      let inline (>>=) f1 f2 x =
+        match f1 x with
+        | Some x' -> Some x'
+        | None -> f2 x
+
+      let params' = 
+        (tryGetChoice1 this.queryParam) 
+          >>= (tryGetChoice1 this.formData) 
+          >>= (tryGetChoice1 <| getFirst this.multiPartFields)
+      
+      params' x  
+      
   [<Obsolete("Renamed to httpVersion")>]
   member x.http_version = x.httpVersion
   [<Obsolete("Renamed to isSecure")>]

--- a/src/Suave/Types.fs
+++ b/src/Suave/Types.fs
@@ -347,14 +347,22 @@ type HttpRequest =
   member x.header k =
     getFirst x.headers k
 
-  /// Gets the form as a ((string*string option list) from the HttpRequest. Use formData to get 
-  /// the data for a particular key.
+  /// Gets the form as a ((string*string option list) from the HttpRequest. 
+  /// Use formData to get the data for a particular key or use the indexed property in the HttpRequest
   member x.form  =
     Parsing.parseData (ASCII.toString x.rawForm)
 
   /// Finds the key k from the form in the HttpRequest
   member x.formData (k : string) =
     getFirstOpt x.form k
+
+
+  /// Syntatic Sugar to retrieve form values from HttpRequest like in Asp.Net Web Pages  
+  member this.Item 
+    with get(x) = 
+      match this.formData x with
+      | Choice1Of2 str -> Some str
+      | Choice2Of2 _ -> None
 
   [<Obsolete("Renamed to httpVersion")>]
   member x.http_version = x.httpVersion

--- a/src/Suave/Utils/Collections.fs
+++ b/src/Suave/Utils/Collections.fs
@@ -26,6 +26,11 @@ let getFirstOpt (target : NameOptionValueList) (key : string) =
   | Some b -> Choice1Of2 b
   | None -> Choice2Of2 (sprintf "Couldn't find key '%s' in NameOptionValueList" key)
 
+let tryGetChoice1 f x =
+  match f x with 
+  | Choice1Of2 str -> Some str
+  | Choice2Of2 _ -> None
+
 let (%%) target key = getFirst target key
 let (^^) target key = getFirstOpt target key
 


### PR DESCRIPTION
Hi,

As the title describes, this pull request adds a indexed property in the http request which enable us to get the form values from the request in a natural way as we used to do in [ASP.NET web pages](http://www.w3schools.com/aspnet/webpages_forms.asp).

![image](https://cloud.githubusercontent.com/assets/1128916/7770748/6d2ed930-00af-11e5-8b53-8a51bdb48395.png)