### PR TITLE
[Cookie] Ignore invalid cookies in requests

### DIFF
--- a/src/Suave.Tests/Cookie.fs
+++ b/src/Suave.Tests/Cookie.fs
@@ -11,7 +11,7 @@ open FsCheck
 open Tests.TestUtilities
 
 [<Tests>]
-let tests =
+let parseResultCookie =
   testList "parse result cookie" [
     testCase "parse path" <| fun _ ->
       let sample = @"st=oFqpYxbMObHvpEW!QLzedHwSZ1gZnotBs$; Path=/; HttpOnly"
@@ -55,4 +55,20 @@ let tests =
       Assert.Equal("should keep bb-valued cookie",
                    "bb",
                    subject.response.cookies.["a"].value)
+    ]
+
+[<Tests>]
+let parseRequestCookies =
+    testList "parse request cookies" [
+        testCase "parse valid cookies" <| fun _ ->
+            let sample = "session=2b14f6a69199243f570031bf94865bb6;abc=123"
+            let result = Cookie.parseCookies sample
+            let expected = [HttpCookie.mkKV "session" "2b14f6a69199243f570031bf94865bb6"
+                            HttpCookie.mkKV "abc" "123"]
+            Assert.Equal("cookies should eq", expected, result)
+
+        testCase "ignore malformed cookies" <| fun _ ->
+            let sample = "session=;value;"
+            let result = Cookie.parseCookies sample
+            Assert.Equal("cookies should be ignored", [], result)
     ]

--- a/src/Suave.Tests/Cookie.fs
+++ b/src/Suave.Tests/Cookie.fs
@@ -60,15 +60,15 @@ let parseResultCookie =
 [<Tests>]
 let parseRequestCookies =
     testList "parse request cookies" [
-        testCase "parse valid cookies" <| fun _ ->
-            let sample = "session=2b14f6a69199243f570031bf94865bb6;abc=123"
-            let result = Cookie.parseCookies sample
-            let expected = [HttpCookie.mkKV "session" "2b14f6a69199243f570031bf94865bb6"
-                            HttpCookie.mkKV "abc" "123"]
-            Assert.Equal("cookies should eq", expected, result)
+      testCase "parse valid cookies" <| fun _ ->
+        let sample = "session=2b14f6a69199243f570031bf94865bb6;abc=123"
+        let result = Cookie.parseCookies sample
+        let expected = [HttpCookie.mkKV "session" "2b14f6a69199243f570031bf94865bb6"
+                        HttpCookie.mkKV "abc" "123"]
+        Assert.Equal("cookies should eq", expected, result)
 
-        testCase "ignore malformed cookies" <| fun _ ->
-            let sample = "session=;value;"
-            let result = Cookie.parseCookies sample
-            Assert.Equal("cookies should be ignored", [], result)
+      testCase "ignore malformed cookies" <| fun _ ->
+        let sample = "session=;value;"
+        let result = Cookie.parseCookies sample
+        Assert.Equal("cookies should be ignored", [], result)
     ]

--- a/src/Suave/Cookie.fs
+++ b/src/Suave/Cookie.fs
@@ -26,9 +26,9 @@ module Cookie =
     |> List.map (fun (cookie : string) ->
         let parts = cookie.Split([|'='|], StringSplitOptions.RemoveEmptyEntries)
         if parts.Length > 1 then
-            Some (HttpCookie.mkKV (String.trim parts.[0]) (String.trim parts.[1]))
+          Some (HttpCookie.mkKV (String.trim parts.[0]) (String.trim parts.[1]))
         else
-            None)
+          None)
     |> List.choose id
 
   let parseResultCookie (s : string) : HttpCookie =

--- a/src/Suave/Cookie.fs
+++ b/src/Suave/Cookie.fs
@@ -21,11 +21,15 @@ module Cookie =
     | DecryptionError of Crypto.SecretboxDecryptionError
 
   let parseCookies (s : string) : HttpCookie list =
-    s.Split(';')
+    s.Split([|';'|], StringSplitOptions.RemoveEmptyEntries)
     |> Array.toList
     |> List.map (fun (cookie : string) ->
-        let parts = cookie.Split('=')
-        HttpCookie.mkKV (String.trim parts.[0]) (String.trim parts.[1]))
+        let parts = cookie.Split([|'='|], StringSplitOptions.RemoveEmptyEntries)
+        if parts.Length > 1 then
+            Some (HttpCookie.mkKV (String.trim parts.[0]) (String.trim parts.[1]))
+        else
+            None)
+    |> List.choose id
 
   let parseResultCookie (s : string) : HttpCookie =
     let parseExpires (str : string) =


### PR DESCRIPTION
Currently when trying to parse a malformed cookie (with a trailing comma or a one sided equals sign), `Cookie.parseCookies` will throw an `IndexOutOfRangeException`. I've added additional checks to said method to prevent this + two unit tests. Invalid cookies are silently ignored.

@ademar suggested on [Gitter](https://gitter.im/SuaveIO/suave?at=55ce71369b45e15c4264466c) that the server should reply with a `BAD_REQUEST` if parsing a cookie fails, or at least log a warning. I like both of these ideas, however they're currently impossible to implement (as far as I know) without changing the function signature and breaking backwards compatibility, since cookies are only parsed when the client asks for them and `parseCookies` has no (and IMO shouldn't have) access to the `HttpContext`.

Maybe a better solution would be to return a `Choice<HttpCookie list, unit> `or a custom discriminated union instead of a list to indicate a parse failure. The user of the API could then decide how to act. Another, stricter approach would be to parse cookies in every incoming request and automatically reject those which cannot be parsed. That could however have performance implications.

This is a temporary solution until such (if any) changes are implemented.