### PR TITLE
logFormat writes size of the object returned to the client

### DIFF
--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -385,11 +385,11 @@ module Http =
     /// 200 is the HTTP status code returned to the client. 2xx is a successful response, 3xx a redirection, 4xx a client error, and 5xx a server error.
     /// 2326 is the size of the object returned to the client, measured in bytes.
     let logFormat (ctx : HttpContext) =
-      
+
       let dash = function | "" | null -> "-" | x -> x
       let ci = Globalization.CultureInfo("en-US")
       let processId = System.Diagnostics.Process.GetCurrentProcess().Id.ToString()
-      sprintf "%O %s %s [%s] \"%s %s %s\" %d %s"
+      sprintf "%O %s %s [%s] \"%s %s %s\" %d %d"
         ctx.request.ipaddr
         processId //TODO: obtain connection owner via Ident protocol
                          // Authentication.UserNameKey
@@ -399,7 +399,9 @@ module Http =
         ctx.request.url.AbsolutePath
         ctx.request.httpVersion
         ctx.response.status.code
-        "0"
+        (match ctx.response.content with
+         | Bytes bs -> bs.LongLength
+         | _ -> 0L)
 
     let log (logger : Logger) (formatter : HttpContext -> string) (ctx : HttpContext) =
       logger.Log LogLevel.Debug <| fun _ ->


### PR DESCRIPTION
With Example app:
```
>curl http://localhost:8082/guid
131ae6d0-ed05-444d-a73c-b485be7dbba5
```

Log before fix:
>[D] 2015-08-28T07:56:11.2846010Z: 127.0.0.1 5064 - [28/Aug/2015:07:56:11 Z] "GET /guid HTTP/1.1" 200 **0** [Suave.Http.web-requests]

Log after fix:
>
[D] 2015-08-28T07:57:48.4286921Z: 127.0.0.1 6632 - [28/Aug/2015:07:57:48 Z] "GET
 /guid HTTP/1.1" 200 **36** [Suave.Http.web-requests]



