### PR TITLE
Accept mixed-case in websockets upgrade header

### DIFF
--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -196,7 +196,7 @@ module WebSocket =
     let r = ctx.request
     if r.``method`` <> HttpMethod.GET then
       return! RequestErrors.METHOD_NOT_ALLOWED "Method not allowed" ctx
-    elif r.header "upgrade"  <> Choice1Of2 "websocket" then 
+    elif r.header "upgrade"  |> Choice.map (fun s -> s.ToLower()) <> Choice1Of2 "websocket" then 
       return! RequestErrors.BAD_REQUEST "Bad Request" ctx
     else
       match r.header "connection" with


### PR DESCRIPTION
IE sends `Upgrade: Websocket`, and according to the RFC, this is even allowed:

    3.   An |Upgrade| header field containing the value "websocket",
        treated as an ASCII case-insensitive value.

Looks like most of Suave codebase uses `ToLower()` rather than `String.Compare(..., StringComparison.InvariantIgnoreCase)`, so I followed the same style.

Also, it would not compile without the change in `State.fs` - but that's what I got when I run `paket restore` with the current `paket.lock` file, so I'm not sure what's happening here!