### PR TITLE
Update FsPickler components

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ nuget FSharp.Core ~> 3.1.2
 nuget Http.fs-prerelease
 nuget RazorEngine
 nuget NuGet.CommandLine
-nuget FsPickler
+nuget FsPickler ~> 1.3
 nuget Fuchu.FsCheck
 nuget Fuchu.PerfUtil ~> 0.6
 nuget Topshelf.FSharp

--- a/paket.lock
+++ b/paket.lock
@@ -7,13 +7,13 @@ NUGET
       FSharp.Core (>= 3.1.2.5)
     FSharp.Charting (0.90.12)
     FSharp.Core (3.1.2.5)
-    FsPickler (1.3.7)
-    Fuchu (0.6.0.0) - framework: net45
-    Fuchu.FsCheck (0.6.0.0)
-      FSharp.Core (>= 3.1.2.1)
+    FsPickler (1.4.0)
+    Fuchu (0.6.0) - framework: net45
+    Fuchu.FsCheck (0.6.0)
       FsCheck (>= 1.0.4)
+      FSharp.Core (>= 3.1.2.1)
       Fuchu (>= 0.6.0.0)
-    Fuchu.PerfUtil (0.6.0.0)
+    Fuchu.PerfUtil (0.6.0)
       FSharp.Core (>= 3.1.2.1)
       Fuchu (>= 0.6.0.0)
       PerfUtil (>= 0.1.8)

--- a/src/Suave/State.fs
+++ b/src/Suave/State.fs
@@ -21,18 +21,13 @@ module CookieStateStore =
   [<Literal>]
   let StateCookie = "st"
 
-  let private encodeMap (map : Map<string, obj>) =
-    let pickler = FsPickler.CreateBinary ()
-    use ms = new MemoryStream()
-    pickler.Serialize(ms, map)
-    ms.ToArray()
 
-  let private decodeMap bytes : Map<string, obj> =
-    let pickler = FsPickler.CreateBinary ()
-    use ms = new MemoryStream()
-    ms.Write (bytes, 0, bytes.Length)
-    ms.Seek (0L, SeekOrigin.Begin) |> ignore
-    pickler.Deserialize ms
+  let private binarySerializer = FsPickler.CreateBinarySerializer ()
+  let private encodeMap (map : Map<string, obj>) : byte [] =
+    binarySerializer.Pickle map
+
+  let private decodeMap (bytes : byte []) : Map<string, obj> =
+    binarySerializer.UnPickle<Map<string, obj>> bytes
 
   let write relativeExpiry (key : string) (value : 'T) =
     context (fun ctx ->


### PR DESCRIPTION
Updates FsPickler related code to work with releases >= 1.3.0. Some simplifications have also been made.