### PR TITLE
ignore letter case in request header names

### DIFF
--- a/src/Suave.Tests/HttpRequestHeaders.fs
+++ b/src/Suave.Tests/HttpRequestHeaders.fs
@@ -7,7 +7,7 @@ open Suave
 [<Tests>]
 let headers (_:SuaveConfig) =
   testList "Request header letter case" [
-    testCase "compare header names case-insentively" <| fun _ ->
+    testCase "compare header names case-insensitively" <| fun _ ->
       let req = { HttpRequest.empty with headers = ["x-suave-customheader", "value"] }
       let actual = req.header "X-Suave-CustomHeader"
       Assert.Equal ("results in Choise1Of2", Choice1Of2 "value", actual)

--- a/src/Suave.Tests/HttpRequestHeaders.fs
+++ b/src/Suave.Tests/HttpRequestHeaders.fs
@@ -1,0 +1,14 @@
+﻿module Suave.Tests.HttpRequestHeaders
+
+open Fuchu
+
+open Suave
+
+[<Tests>]
+let headers (_:SuaveConfig) =
+  testList "Request header letter case" [
+    testCase "compare header names case-insentively" <| fun _ ->
+      let req = { HttpRequest.empty with headers = ["x-suave-customheader", "value"] }
+      let actual = req.header "X-Suave-CustomHeader"
+      Assert.Equal ("results in Choise1Of2", Choice1Of2 "value", actual)
+    ]

--- a/src/Suave.Tests/Suave.Tests.fsproj
+++ b/src/Suave.Tests/Suave.Tests.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="HttpVerbs.fs" />
     <Compile Include="HttpApplicatives.fs" />
     <Compile Include="HttpAuthentication.fs" />
+    <Compile Include="HttpRequestHeaders.fs" />
     <Compile Include="Parsing.fs" />
     <Compile Include="Model.fs" />
     <Compile Include="Perf.fs" />

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -323,7 +323,8 @@ module Http =
       getFirstOpt x.query key
 
     member x.header key =
-      getFirst x.headers key
+      // Field names are case-insensitive (RFC 2616 section 4.2)
+      getFirstIgnoreCase x.headers key
 
     member x.form =
       Parsing.parseData (ASCII.toString x.rawForm)

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -324,7 +324,7 @@ module Http =
 
     member x.header key =
       // Field names are case-insensitive (RFC 2616 section 4.2)
-      getFirstIgnoreCase x.headers key
+      getFirstCaseInsensitve x.headers key
 
     member x.form =
       Parsing.parseData (ASCII.toString x.rawForm)

--- a/src/Suave/Model.fs
+++ b/src/Suave/Model.fs
@@ -38,7 +38,7 @@ module Binding =
     bind (Aether.Lens.get HttpContext.request_ >> f) fCont fErr
 
   let header key f (req : HttpRequest) =
-    (getFirst req.headers key)
+    req.header key
     |> Choice.mapSnd (fun _ -> sprintf "Missing header '%s'" key)
     |> Choice.bind f
 

--- a/src/Suave/Utils/Collections.fs
+++ b/src/Suave/Utils/Collections.fs
@@ -2,7 +2,6 @@
 [<AutoOpen>]
 module Suave.Utils.Collections
 
-open System
 open System.Collections.Generic
 
 /// A (string * string) list, use (%%) to access
@@ -22,8 +21,8 @@ let getFirst (target : NameValueList) (key : string) =
   | Some b -> Choice1Of2 b
   | None   -> Choice2Of2 (sprintf "Couldn't find key '%s' in NameValueList" key)
 
-let getFirstIgnoreCase (target : NameValueList) (key : string) =
-  match target |> List.tryPick (fun (a, b) -> if a.Equals (key, StringComparison.InvariantCultureIgnoreCase) then Some b else None) with
+let getFirstCaseInsensitve (target : NameValueList) (key : string) =
+  match target |> List.tryPick (fun (a, b) -> if String.equalsCaseInsensitve a key then Some b else None) with
   | Some b -> Choice1Of2 b
   | None   -> Choice2Of2 (sprintf "Couldn't find key '%s' in NameValueList" key)
 

--- a/src/Suave/Utils/Collections.fs
+++ b/src/Suave/Utils/Collections.fs
@@ -2,6 +2,7 @@
 [<AutoOpen>]
 module Suave.Utils.Collections
 
+open System
 open System.Collections.Generic
 
 /// A (string * string) list, use (%%) to access
@@ -18,6 +19,11 @@ type IDictionary<'b,'a> with
 
 let getFirst (target : NameValueList) (key : string) =
   match target |> List.tryPick (fun (a, b) -> if a.Equals key then Some b else None) with
+  | Some b -> Choice1Of2 b
+  | None   -> Choice2Of2 (sprintf "Couldn't find key '%s' in NameValueList" key)
+
+let getFirstIgnoreCase (target : NameValueList) (key : string) =
+  match target |> List.tryPick (fun (a, b) -> if a.Equals (key, StringComparison.InvariantCultureIgnoreCase) then Some b else None) with
   | Some b -> Choice1Of2 b
   | None   -> Choice2Of2 (sprintf "Couldn't find key '%s' in NameValueList" key)
 


### PR DESCRIPTION
This PR fixes a problem that a query always falls into `Choice2Of2` (failure) when a key to look up contains any character in upper case (#370).

According to RCF 2616, field names of HTTP header are case-insensitive.
Thus, the behavior above is a bug.

How to resolve:
* adding a new function `getFirstIgnoreCase` which searches a key in a collection case-insensitively.
* changing `HttpRequest.header` function to use the `getFirstIgnoreCase` function instead of `getFirst` to follow the RFC.
