### PR TITLE
Fix routing docs

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -22,6 +22,7 @@ A WebPart function returns an asynchronous workflow which itself ultimately retu
 {% highlight fsharp %}        
 open Suave
 open Suave.Filters
+open Suave.Operators
 open Suave.Successful
 
 let app =


### PR DESCRIPTION
https://suave.io/routing.html

The code results in the error "Expecting a type supporting the operator
'>=>' but given a function type. You may be missing an argument to a
function." due to the lack of `open Suave.Operators`. This is caused by
the need to open `Suave.Operators` to get access to the "fish" operator in
release 1.0.0.