### PR TITLE
rewrite HTML to be more aligned with spec

### DIFF
--- a/src/Experimental/Suave.Experimental.fsproj
+++ b/src/Experimental/Suave.Experimental.fsproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
     <Compile Include="Html.fs" />
+    <Compile Include="Xml.fs" />
     <Compile Include="Template.fs" />
     <Compile Include="Data.fs" />
     <Compile Include="Form.fs" />

--- a/src/Experimental/Template.fs
+++ b/src/Experimental/Template.fs
@@ -11,7 +11,7 @@ open System.Reflection
 open System.Text
 
 open Suave.Web
-open Suave.Html
+open Suave.Xml
 open Suave.Operators
 
 /// Load an object from its name

--- a/src/Experimental/Xml.fs
+++ b/src/Experimental/Xml.fs
@@ -1,0 +1,135 @@
+﻿module Suave.Xml
+
+open System
+
+type Attribute = string * string
+
+/// Representation of the things that go into an HTML element
+type Element =
+  /// The element itself; a name, a xml namespace and an array of attribute-value pairs.
+  | Element of string * string * Attribute[]
+  /// A text element inside the HTML element
+  | Text of string
+  /// Whitespace for formatting
+  | WhiteSpace of string
+
+/// XML is a list of nodes
+type Xml = Xml of Node list
+/// Each node has/is an element and then some other XML
+and Node = Element * Xml
+
+let tag tag attr (contents : Xml) = Xml [ (Element (tag,"", Array.ofList attr), contents) ]
+
+let empty = Xml[]
+
+let text s = Xml([Text s, Xml[]])
+
+let emptyText = text ""
+
+/// HTML elements.
+/// If you need to pass attributes use the version sufixed by ` (funny quote symbol)
+
+/// Flattens an XML list
+let flatten xs = xs |> List.map (fun (Xml y) -> y) |> List.concat |> Xml
+
+
+let htmlAttr attr s = tag "html" attr s
+let html xs = htmlAttr [ ] (flatten xs)
+
+let headAttr attr s = tag "head" attr s
+let head xs = headAttr [ ] (flatten xs)
+
+let titleAttr attr s = tag "title" attr (Xml([Text s,Xml []]))
+let title  = titleAttr [ ]
+
+let linkAttr attr = tag "link" attr empty
+let link  = linkAttr [ ]
+
+let scriptAttr attr x = tag "script" attr (flatten x)
+let script  = scriptAttr [ ]
+
+let bodyAttr attr x = tag "body" attr (flatten x)
+let body  = bodyAttr [ ]
+
+let divAttr attr x = tag "div" attr (flatten x)
+let div  = divAttr [ ]
+
+let pAttr attr x = tag "p" attr (flatten x)
+let p  = pAttr [ ]
+
+let spanAttr attr x = tag "span" attr x
+let span  = spanAttr [ ]
+
+let imgAttr attr = tag "img" attr empty
+let img  = imgAttr [ ]
+
+let brAttr attr = tag "br" attr empty
+let br = brAttr [ ]
+
+let inputAttr attr = tag "input" attr empty
+let input = inputAttr [ ]
+
+/// Example
+
+let samplePage =
+  html [
+    head [
+      title "Little HTML DSL"
+      linkAttr [ "rel", "https://instabt.com/instaBT.ico" ]
+      scriptAttr [ "type", "text/javascript"; "src", "js/jquery-2.1.0.min.js" ] []
+      scriptAttr [ "type", "text/javascript" ] [ text "$().ready(function () { setup(); });" ]
+    ]
+    body [
+      divAttr ["id","content"] [
+        p [ text "Hello world." ]
+        br
+        imgAttr [ "src", "http://fsharp.org/img/logo/fsharp256.png"]
+      ]
+    ]
+ ]
+
+/// Rendering
+
+let internal leafElementToString = function
+ | Text text -> text
+ | WhiteSpace text -> text
+ | Element (e,id, attributes) ->
+   if Array.length attributes = 0 then
+     sprintf "<%s/>" e
+   else
+     let ats =
+       Array.map (fun (a,b) -> sprintf "%s=\"%s\"" a b) attributes
+       |> String.Concat
+     sprintf "<%s %s/>" e ats
+
+let internal beginElementToString = function
+ | Text text -> failwith "invalid option"
+ | WhiteSpace text -> failwith "invalid option"
+ | Element (e,id, attributes) ->
+   if Array.length attributes = 0 then
+     sprintf "<%s>" e
+   else
+     let ats =
+       Array.map (fun (a,b) -> sprintf "%s=\"%s\"" a b) attributes
+       |> String.Concat
+     sprintf "<%s %s>" e ats
+
+let internal endElementToString = function
+ | Text text -> failwith "invalid option"
+ | WhiteSpace text -> failwith "invalid option"
+ | Element (e,_, _) ->
+   sprintf "</%s>" e
+
+let rec internal nodeToString (element : Element, xml) =
+  match xml with
+  | Xml [] -> leafElementToString element
+  | _  ->
+    let inner = xmlToString xml
+    (beginElementToString element) + inner + (endElementToString element)
+
+and xmlToString (Xml xml) =
+  String.Concat (List.map nodeToString xml)
+
+///
+/// let html = samplePage |> xmlToString
+///


### PR DESCRIPTION
This should fix #403. I kept renamed the old one to Suave.Xml, since that is more generic and not true HTML as by the specification.

I also simplified the code for the HTML part.

The renaming is a breaking change for the HTML, but thought it is ok since it is in Experimental. Ok?