### PR TITLE
renderHtmlDocument to add doctype to HTML documents and add a tag.

### DIFF
--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -62,13 +62,13 @@ let linkAttr attr = voidTag "link" attr
 let link = linkAttr [ ]
 
 let metaAttr attr = voidTag "meta" attr
-let meta = linkAttr [ ]
+let meta = metaAttr [ ]
 
 let hrAttr attr = voidTag "hr" attr
-let hr = linkAttr [ ]
+let hr = hrAttr [ ]
 
 let brAttr attr = voidTag "br" attr
-let br = linkAttr [ ]
+let br = brAttr [ ]
 
 /// Example
 

--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -45,6 +45,9 @@ let div = divAttr [ ]
 let pAttr = tag "p"
 let p = pAttr [ ]
 
+let aAttr href attr = tag "a" (("href",href)::attr)
+let a href = aAttr href [ ]
+
 let spanAttr = tag "span"
 let span  = spanAttr [ ]
 

--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -112,6 +112,8 @@ let rec htmlToString node =
     sprintf "%s%s%s" startTag inner endTag
   | VoidElement e -> e |> startElemToString
 
+let renderHtmlDocument document =
+  sprintf "<!DOCTYPE html>%s%s" (Environment.NewLine) (document |> htmlToString)
 ///
 ///let sample = samplePage |> htmlToString
 ///


### PR DESCRIPTION
* Add support to render doctype easily. Fixes #407 .
* Add `a` tag (link) to `Html.fs`, the implementation of the `a` tag requires `href`. Fixes #409 
