### PR TITLE
[build] change tests dir from 'Debug' to 'Release'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,8 +73,16 @@ task :libs do
     7z x v1.7.5.zip & cd libuv-1.7.5 & vcbuild.bat x86 shared debug
     mkdir src\\Suave.Tests\\bin\\Release\\ & cp libuv-1.7.5\\Debug\\libuv.dll src\\Suave.Tests\\bin\\Release\\libuv.dll
 
-  On Linux:
-    ...
+  On Linux Ubuntu/Debian:
+    sudo apt-get install automake libtool
+    curl -sSL https://github.com/libuv/libuv/archive/v1.7.5.tar.gz | sudo tar zxfv - -C /usr/local/src
+    cd /usr/local/src/libuv-1.7.5
+    sudo sh autogen.sh
+    sudo ./configure
+    sudo make 
+    sudo make install
+    sudo rm -rf /usr/local/src/libuv-1.7.5 && cd ~/
+    sudo ldconfig
   }
       end
     end

--- a/build.sh
+++ b/build.sh
@@ -29,4 +29,4 @@ echo 'Building'
 xbuild src/Suave.sln /p:Configuration=Release
 
 echo 'Running tests'
-mono src/Suave.Tests/bin/Debug/Suave.Tests.exe
+mono src/Suave.Tests/bin/Release/Suave.Tests.exe


### PR DESCRIPTION
`xbuild` is invoked with `/p:Configuration=Release` hence it didn't find proper test binary in `Debug`

also copied instructions for installing libuv on Ubuntu/Debian from [aspnet wiki](https://github.com/aspnet/Home/wiki/Getting-Started-Prerequisites-for-Debian,-Ubuntu-and-derivitives#get-libuv)