### PR TITLE
Custom mapJson2

### DIFF
--- a/src/Suave/Json.fs
+++ b/src/Suave/Json.fs
@@ -21,15 +21,20 @@ let fromJson<'T> (bytes : byte []) =
   ms.Seek(0L, SeekOrigin.Begin) |> ignore
   dcs.ReadObject(ms) :?> 'T
 
+/// Expose function f through a json call where you decide
+/// which serializer to use.
+
+let mapJsonWith<'TIn, 'TOut> (deserializer:byte[] -> 'TIn) (serializer:'TOut->byte[]) f =
+  request(fun r ->
+    f (deserializer r.rawForm)
+    |> serializer
+    |> Successful.ok
+    >=> Writers.setMimeType "application/json")
+
 /// Expose function f through a json call; lets you write like
 ///
 /// let app =
 ///   url "/path"  >>= map_json some_function;
 ///
 
-let mapJson f =
-  request(fun r ->
-    f (fromJson r.rawForm) 
-    |> toJson
-    |> Successful.ok 
-    >=> Writers.setMimeType "application/json")
+let mapJson<'T1,'T2> = mapJsonWith<'T1,'T2> fromJson toJson


### PR DESCRIPTION
The existing mapJson only allows for the standard serializer.
mapJson2 (name can be discussed) makes it possible to provide
serializer and deserializer.