### PR TITLE
[WIP] distinguish dotnet cli nupkgs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
    - arch: "x64"
      MSBUILD_PLATFORM: "Any CPU"
      USE_DOTNET_CLI: 1
-     USE_DOTNET_CLI_VERSION: Latest
+     USE_DOTNET_CLI_VERSION: 1.0.0-beta-002071
 
 install:
  - ps: Start-FileDownload 'https://github.com/libuv/libuv/archive/v1.7.5.zip'

--- a/src/Suave/project.json
+++ b/src/Suave/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0-alpha-dotnetcli",
     "compilationOptions": {
     },
 


### PR DESCRIPTION
Trying to achieve what I asked on gitter - would like to consume dotnetcli nupkg from app
For now I've set version in project.json to `2.0.0-alpha-dotnetcli` - that's probably just a temporary solution
I think that in the end the `netstandard` framework binaries should be somehow incorporated into the main nupkg, but not really sure how this should be done

Also, I've queued build on appveyor to preview what those nupkgs would look like: https://ci.appveyor.com/project/theimowski/suave/build/1.0.2/job/2n5q8xhs90q4ax2m 

CC: @enricosada 