### PR TITLE
basic authentication with cookie suppport

### DIFF
--- a/src/Suave/Authentication.fsi
+++ b/src/Suave/Authentication.fsi
@@ -41,6 +41,12 @@ val authenticateWithLogin : relativeExpiry:CookieLife
                           -> fSuccess:WebPart
                           -> WebPart
 
+val authenticateBasicWithCookie : relativeExpiry:CookieLife
+                                -> secure:bool
+                                -> validationFunction:(string * string -> bool)
+                                -> fSuccess:WebPart
+                                -> WebPart
+
 /// Set server-signed cookies to make the response contain a cookie
 /// with a valid session id. It's worth having in mind that when you use this web
 /// part, you're setting cookies on the response; so you'll need to have the


### PR DESCRIPTION
When using basic auth the header isn't accessible that easy from javascript, or at least I didn't find a nice way. Storing the authorization data in a cookie when logged in makes it easy to create a web page with js-app that supports basic auth, the js-app can just use the cookie.

If rejected, please tell how it should be done. If accepted, please check and comment on the `authenticateBasicWithCookie` method. It feels like it might be a nicer way to write it.