### PR TITLE
Ability to set dotliquid naming convention directly

### DIFF
--- a/src/Suave.DotLiquid/Library.fs
+++ b/src/Suave.DotLiquid/Library.fs
@@ -87,6 +87,16 @@ let private loadTemplateCached =
 
 let mutable private templatesDir = None
 
+
+// Sets the DotLiquid naming convention to the Ruby style. F# values in camelCase
+// will be converted to not_camel_case in templates. This is the default
+let setRubyNamingConvention = 
+  Template.NamingConvention <- DotLiquid.NamingConventions.RubyNamingConvention()
+  
+// Sets the DotLiquid naming convetion to the CSharp style, will preserve camelCase
+let setCSharpNamingConvention = 
+  Template.NamingConvention <- DotLiquid.NamingConventions.CSharpNamingConvention()
+
 /// Set the root directory where DotLiquid is looking for templates. For example, you can 
 /// write something like this:
 ///

--- a/src/Suave.DotLiquid/Library.fs
+++ b/src/Suave.DotLiquid/Library.fs
@@ -90,11 +90,11 @@ let mutable private templatesDir = None
 
 // Sets the DotLiquid naming convention to the Ruby style. F# values in camelCase
 // will be converted to not_camel_case in templates. This is the default
-let setRubyNamingConvention = 
+let setRubyNamingConvention _ = 
   Template.NamingConvention <- DotLiquid.NamingConventions.RubyNamingConvention()
   
 // Sets the DotLiquid naming convetion to the CSharp style, will preserve camelCase
-let setCSharpNamingConvention = 
+let setCSharpNamingConvention _ = 
   Template.NamingConvention <- DotLiquid.NamingConventions.CSharpNamingConvention()
 
 /// Set the root directory where DotLiquid is looking for templates. For example, you can 


### PR DESCRIPTION
Helper functions to set the DotLiquid naming convention.  the CSharp naming convention is much preferred as it will preserve camelCase rather than convert it to not_camel_case.

You might want to also change the default to CSharp instead of Ruby, though that will be a breaking change.
