### PR TITLE
Feature/authenticationlogout

### DIFF
--- a/src/Suave/Authentication.fs
+++ b/src/Suave/Authentication.fs
@@ -1,11 +1,12 @@
 ﻿module Suave.Authentication
 
-open System
 open System.Text
 open Suave.RequestErrors
 open Suave.Utils
 open Suave.Logging
 open Suave.Cookie
+open Suave.Operators
+open Suave.State.CookieStateStore
 
 let UserNameKey = "userName"
 
@@ -98,8 +99,15 @@ let authenticated relativeExpiry secure : WebPart =
                  (fun _ -> Choice1Of2 data)
                  succeed)
 
-//  let deauthenticate : WebPart =
-//    Cookies.unset_cookies
+let deauthenticate _ : WebPart =
+  unsetPair SessionAuthCookie 
+  >=> unsetPair StateCookie
+
+let deauthenticateWithLogin loginPage : WebPart =
+  deauthenticate()
+  >=> Redirection.FOUND loginPage
+
+
   
 module HttpContext =
 

--- a/src/Suave/Authentication.fsi
+++ b/src/Suave/Authentication.fsi
@@ -41,6 +41,13 @@ val authenticateWithLogin : relativeExpiry:CookieLife
                           -> fSuccess:WebPart
                           -> WebPart
 
+val deauthenticate : _
+                   -> WebPart
+
+val deauthenticateWithLogin : loginPage :string
+                            -> WebPart
+  
+
 /// Set server-signed cookies to make the response contain a cookie
 /// with a valid session id. It's worth having in mind that when you use this web
 /// part, you're setting cookies on the response; so you'll need to have the


### PR DESCRIPTION
Adds deauthenticate and deauthenticateWithLogin functions to mirror the existing authenticate functions. Also adds to the authenticate testcase to ensure that protected content can not be accessed after deauthenticate.