### PR TITLE
Add deauthenticate functions

### DIFF
--- a/src/Suave/Authentication.fs
+++ b/src/Suave/Authentication.fs
@@ -6,6 +6,9 @@ open Suave.RequestErrors
 open Suave.Utils
 open Suave.Logging
 open Suave.Cookie
+open Suave.State.CookieStateStore
+open Suave.Operators
+
 
 let UserNameKey = "userName"
 
@@ -98,9 +101,14 @@ let authenticated relativeExpiry secure : WebPart =
                  (fun _ -> Choice1Of2 data)
                  succeed)
 
-//  let deauthenticate : WebPart =
-//    Cookies.unset_cookies
-  
+let deauthenticate : WebPart =
+ unsetPair SessionAuthCookie
+ >=> unsetPair StateCookie
+
+let deauthenticateWithLogin loginPage : WebPart =
+ deauthenticate
+ >=> Redirection.FOUND loginPage
+
 module HttpContext =
 
   let sessionId x =

--- a/src/Suave/Authentication.fsi
+++ b/src/Suave/Authentication.fsi
@@ -41,6 +41,13 @@ val authenticateWithLogin : relativeExpiry:CookieLife
                           -> fSuccess:WebPart
                           -> WebPart
 
+/// Deauthenticates, or 'logs out' the user
+val deauthenticate : WebPart
+
+/// Deauthenticates the user and then sends them to path specified by loginPage string
+val deauthenticateWithLogin : loginPage :string
+                            -> WebPart
+
 /// Set server-signed cookies to make the response contain a cookie
 /// with a valid session id. It's worth having in mind that when you use this web
 /// part, you're setting cookies on the response; so you'll need to have the


### PR DESCRIPTION
deauthenticate and deauthenticateWithLogin functions for easier / more obvious logout functionality
Atom seems to  have auto-removed some trailing whitespace too, hope that is ok!