### PR TITLE
Allow '=' in cookie-values (ref RFC6265)

### DIFF
--- a/src/Suave.Tests/Cookie.fs
+++ b/src/Suave.Tests/Cookie.fs
@@ -60,14 +60,15 @@ let parseResultCookie (_:SuaveConfig) =
 let parseRequestCookies (_ : SuaveConfig) =
     testList "parse request cookies" [
       testCase "parse valid cookies" <| fun _ ->
-        let sample = "session=2b14f6a69199243f570031bf94865bb6;abc=123"
+        let sample = "session=2b14f6a69199243f570031bf94865bb6;abc=123;alphaplusvalues=!#$%&'()*+-./:<=>?@[]^_`{|}~"
         let result = Cookie.parseCookies sample
         let expected = [HttpCookie.mkKV "session" "2b14f6a69199243f570031bf94865bb6"
-                        HttpCookie.mkKV "abc" "123"]
+                        HttpCookie.mkKV "abc" "123"
+                        HttpCookie.mkKV "alphaplusvalues" "!#$%&'()*+-./:<=>?@[]^_`{|}~"]
         Assert.Equal("cookies should eq", expected, result)
 
       testCase "ignore malformed cookies" <| fun _ ->
-        let sample = "session=;value;"
+        let sample = "session=;value;anothervalue= "
         let result = Cookie.parseCookies sample
         Assert.Equal("cookies should be ignored", [], result)
     ]

--- a/src/Suave/Cookie.fs
+++ b/src/Suave/Cookie.fs
@@ -21,12 +21,13 @@ module Cookie =
   let parseCookies (s : string) : HttpCookie list =
     s.Split([|';'|], StringSplitOptions.RemoveEmptyEntries)
     |> Array.toList
+    |> List.map (String.trim)
     |> List.map (fun (cookie : string) ->
-        let parts = cookie.Split([|'='|], StringSplitOptions.RemoveEmptyEntries)
-        if parts.Length > 1 then
-          Some (HttpCookie.mkKV (String.trim parts.[0]) (String.trim parts.[1]))
-        else
-          None)
+        match cookie.IndexOf("=") with
+        | idx when idx + 1 = cookie.Length -> None // no value is set
+        | idx when idx > 1 -> Some (HttpCookie.mkKV (String.trim (cookie.Substring(0, idx))) (String.trim (cookie.Substring(idx + 1))))
+        | _ -> None)
+
     |> List.choose id
 
   let parseResultCookie (s : string) : HttpCookie =


### PR DESCRIPTION
Cookie values should be allowed to contain the equals character. Some (ie.asp.net)  apps use equals to make the cookie value an array. 

check out [RFC6265 ](http://www.ietf.org/rfc/rfc6265.txt)for reference