### PR TITLE
Add mimetype application/woff2 used by FontAwesome (and others)

### DIFF
--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -108,6 +108,7 @@ module Writers =
     | ".ttf" -> mkMimeType "application/x-font-ttf" true
     | ".otf" -> mkMimeType "application/font-sfnt" true
     | ".woff" -> mkMimeType "application/font-woff" false
+    | ".woff2" -> mkMimeType "application/font-woff2" false
     | ".eot" -> mkMimeType "application/vnd.ms-fontobject" false
     | _      -> None
 


### PR DESCRIPTION
A tiny change to add the woff2 mime type.  I ran into this when trying to serve FontAwesome with Suave.  I believe the file format is still in draft but it seems like it's getting used.

https://dev.w3.org/webfonts/WOFF2/spec/
http://stackoverflow.com/questions/28235550/proper-mime-type-for-woff2-fonts

