### PR TITLE
[dotliquid] Support rendering from file to string, or string to string

### DIFF
--- a/src/Suave.Tests/DotLiquid.fs
+++ b/src/Suave.Tests/DotLiquid.fs
@@ -1,0 +1,34 @@
+﻿module Suave.Tests.DotLiquid
+
+open Fuchu
+open Suave
+open System.IO
+
+type M1 =
+  { name : string }
+
+[<Tests>]
+let tests =
+  testList "DotLiquid templating with Suave" [
+    DotLiquid.setTemplatesDir TestUtilities.currentPath
+    let combine lastBit = Path.Combine(TestUtilities.currentPath, lastBit)
+
+    yield testCase "can render a page" <| fun () ->
+      let subject =
+        DotLiquid.renderPageFile (combine "liquid/hello.liquid") { M1.name = "haf" }
+        |> Async.RunSynchronously
+      Assert.Equal("should render properly", "Hi haf", subject)
+
+    yield testCase "can render a page & master" <| fun () ->
+      let subject =
+        DotLiquid.renderPageFile (combine "liquid/child.liquid") { M1.name = "haf2" }
+        |> Async.RunSynchronously
+      Assert.Equal("should render parent and child", "Parent\nHi haf2", subject)
+
+    yield testCase "can render from string" <| fun () ->
+      let subject =
+        DotLiquid.renderPageString "Hi {{ model.name }}" { M1.name = "haf3" }
+        |> Async.RunSynchronously
+
+      Assert.Equal("should render Hello", "Hi haf3", subject)
+    ]

--- a/src/Suave.Tests/Suave.Tests.fsproj
+++ b/src/Suave.Tests/Suave.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -106,6 +106,7 @@
     <Compile Include="Types.fs" />
     <Compile Include="WebSocket.fs" />
     <Compile Include="Razor.fs" />
+    <Compile Include="DotLiquid.fs" />
     <Compile Include="FuchuExtensions.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />
@@ -147,6 +148,15 @@
     <Content Include="fallback.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="liquid\hello.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="liquid\parent.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="liquid\child.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -170,6 +180,10 @@
     <ProjectReference Include="..\Suave.LibUv\Suave.LibUv.fsproj">
       <Project>{7C787110-A146-4021-8163-40137E325DB4}</Project>
       <Name>Suave.LibUv</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Suave.DotLiquid\Suave.DotLiquid.fsproj">
+      <Project>{4E3FE86D-FDB7-4DAA-8D58-13F06F75D240}</Project>
+      <Name>Suave.DotLiquid</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>
@@ -271,4 +285,7 @@
       </ItemGroup>
     </When>
   </Choose>
+  <ItemGroup>
+    <Folder Include="liquid\" />
+  </ItemGroup>
 </Project>

--- a/src/Suave.Tests/liquid/child.liquid
+++ b/src/Suave.Tests/liquid/child.liquid
@@ -1,0 +1,2 @@
+﻿{% extends "liquid/parent.liquid" %}
+{% block main %}Hi {{ model.name }}{% endblock %}

--- a/src/Suave.Tests/liquid/hello.liquid
+++ b/src/Suave.Tests/liquid/hello.liquid
@@ -1,0 +1,1 @@
+﻿Hi {{ model.name }}

--- a/src/Suave.Tests/liquid/parent.liquid
+++ b/src/Suave.Tests/liquid/parent.liquid
@@ -1,0 +1,2 @@
+﻿Parent
+{% block main %}{% endblock %}

--- a/src/Suave.Tests/paket.references
+++ b/src/Suave.Tests/paket.references
@@ -6,3 +6,4 @@ Fuchu.FsCheck
 Fuchu.PerfUtil
 WebSocketSharp
 Http.fs-prerelease
+DotLiquid


### PR DESCRIPTION
This PR adds support for different modes of rendering, parametrising the template-parse/rendering function.

It makes will make it easier to use Suave.DotLiquid for rendering things like transactional e-mail.