### PR TITLE
Emit preamble for EventSource

### DIFF
--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -697,6 +697,7 @@ module EventSource =
   let private handShakeAux f (out : Connection, _) =
     socket {
       let! (_,out) = asyncWriteLn "" out// newline after headers
+      let! out = flush out // must flush lines buffer before using asyncWriteBytes
 
       // Buggy Internet Explorer; 2kB of comment padding for IE
       do! String.replicate 2000 " " |> comment out


### PR DESCRIPTION
EventSource should emit the preamble, but it communicates over the
connection through the asyncWriteBytes primitive, which does not flush
the line buffer.

This can be fixed by manually flushing the buffer before starting the
event data stream.

Fixes the output of examples/Example/es.html