### PR TITLE
appveyor rake task create the package with .net core

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -272,8 +272,11 @@ end
 desc 'create suave nuget'
 task :nugets => ['build/pkg', :versioning, :compile, :create_nuget_quick]
 
+desc 'create suave nuget with .NET Core'
+task :nugets_with_netcore => [:nugets, 'dotnetcli:do_netcorepackage', 'dotnetcli:merge']
+
 desc 'compile, gen versions, test and create nuget'
-task :appveyor => [:compile, :'tests:unit', :nugets]
+task :appveyor => [:compile, :'tests:unit', :nugets_with_netcore]
 
 desc 'compile, gen versions, test'
 task :default => [:compile, :'tests:unit', :'docs:build']

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
      MSBUILD_PLATFORM: x86
    - arch: "x64"
      MSBUILD_PLATFORM: "Any CPU"
-   - arch: "x64"
-     MSBUILD_PLATFORM: "Any CPU"
-     USE_DOTNET_CLI: 1
 
 install:
  - ps: Start-FileDownload 'https://github.com/libuv/libuv/archive/v1.7.5.zip'
@@ -20,11 +17,6 @@ build_script:
  - cmd: gem install bundler --no-ri --no-rdoc --source http://rubygems.org/
  - cmd: bundle install
  - cmd: bundle exec rake appveyor
- # dotnet cli
- # - create Suave coreclr nugets packages
- - cmd: if "%USE_DOTNET_CLI%" == "1" bundle exec rake dotnetcli:do_netcorepackage
- # - merge standard and dotnetcli nupkgs
- - cmd: if "%USE_DOTNET_CLI%" == "1" bundle exec rake dotnetcli:merge
  
 artifacts:
  - path: build\pkg\*.nupkg 


### PR DESCRIPTION
ref #444

Added `rake nugets_with_netcore`, and `rake appveyor` now depends on `nugets_with_netcore`
i didnt change the `rake nugets` because people may use it, your call.

removed the now useless build matrix job, because appveyor now create the final package with .NET Core too
