### PR TITLE
Optionally check origin for WebSockets connection

### DIFF
--- a/examples/WebSocket/Program.fs
+++ b/examples/WebSocket/Program.fs
@@ -8,7 +8,7 @@ open Suave.Files
 open Suave.RequestErrors
 open Suave.Logging
 open Suave.Utils
-
+open Suave.CORS
 open System
 open System.Net
 
@@ -33,9 +33,11 @@ let echo (webSocket : WebSocket) =
       | _ -> ()
   }
 
+let corsConfig = { defaultCORSConfig with allowedUris = InclusiveOption.Some [ "http://localhost:8083" ]; checkWebSocketOrigin = false }
+
 let app : WebPart =
   choose [
-    path "/websocket" >=> handShake echo
+    path "/websocket" >=> cors corsConfig >=> handShake echo
     GET >=> choose [ path "/" >=> file "index.html"; browseHome ];
     NOT_FOUND "Found no handlers."
     ]

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -800,6 +800,7 @@ module CORS =
     static member allowCookies_          = Property<CORSConfig,_> (fun x -> x.allowCookies)          (fun v x -> { x with allowCookies = v })
     static member exposeHeaders_         = Property<CORSConfig,_> (fun x -> x.exposeHeaders)         (fun v x -> { x with exposeHeaders = v })
     static member maxAge_                = Property<CORSConfig,_> (fun x -> x.maxAge)                (fun v x -> { x with maxAge = v })
+    static member checkWebSocketOrigin_  = Property<CORSConfig,_> (fun x -> x.checkWebSocketOrigin)  (fun v x -> { x with checkWebSocketOrigin = v })
 
   let private isAllowedOrigin config (value : string) = 
     match config.allowedUris with
@@ -891,7 +892,7 @@ module CORS =
               >=> setAllowMethodsHeader config "*"
             composed ctx
           else
-            if (config.checkWebSocketOrigin && (req.header "upgrade"  |> Choice.map (fun s -> s.ToLower()) = Choice1Of2 "websocket")) then fail
+            if config.checkWebSocketOrigin && (req.header "upgrade"  |> Choice.map (fun s -> s.ToLowerInvariant()) = Choice1Of2 "websocket") then fail
             else succeed ctx // No headers will be sent. Browser will deny.
 
       | Choice2Of2 _ ->

--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -1575,7 +1575,10 @@ module CORS =
       exposeHeaders           : bool
       
       /// Max age in seconds the user agent is allowed to cache the result of the request.
-      maxAge                  : int option }
+      maxAge                  : int option
+      
+      /// Should WebSocket connections be checked for origin?
+      checkWebSocketOrigin    : bool }
     
     static member allowedUris_           : Property<CORSConfig, InclusiveOption<string list>>
     static member allowedMethods_        : Property<CORSConfig, InclusiveOption<HttpMethod list>>

--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -199,7 +199,7 @@ module WebSocket =
     let r = ctx.request
     if r.``method`` <> HttpMethod.GET then
       return! RequestErrors.METHOD_NOT_ALLOWED "Method not allowed" ctx
-    elif r.header "upgrade"  |> Choice.map (fun s -> s.ToLower()) <> Choice1Of2 "websocket" then
+    elif r.header "upgrade"  |> Choice.map (fun s -> s.ToLowerInvariant()) <> Choice1Of2 "websocket" then
       return! RequestErrors.BAD_REQUEST "Bad Request" ctx
     else
       match r.header "connection" with


### PR DESCRIPTION
This is a very small addition which is convenient to do via config. A relevant [question](http://stackoverflow.com/questions/23674199/why-is-there-no-same-origin-policy-for-websockets-why-can-i-connect-to-ws-loc) on SO.