### PR TITLE
fix .net core examples/Example

### DIFF
--- a/examples/Example/project.json
+++ b/examples/Example/project.json
@@ -14,7 +14,7 @@
         
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Suave": "2.0.0-alpha2",
+    "Suave": "2.0.0-alpha4",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0-rc2-3002702"


### PR DESCRIPTION
i'd like also to add the following doc about how to run the example with .net core (because is new), should i add a README.md in the directory? another location?

with .NET Core sdk preview 1 installed

```
cd examples/Example
dotnet restore
dotnet run
```
