### PR TITLE
Fix for #458

### DIFF
--- a/src/Suave/ConnectionFacade.fs
+++ b/src/Suave/ConnectionFacade.fs
@@ -336,7 +336,7 @@ type ConnectionFacade(ctx) =
           let! a = skip (boundary.Length)
           return () 
 
-        | Choice1Of2 contentType ->
+        | Choice1Of2 contentType when headerParams.ContainsKey "filename" ->
           verbosef (fun f -> f "parsing content type %s -> readFilePart" contentType)
           let! res = readFilePart boundary  headerParams fieldName contentType
           verbosef (fun f -> f "parsing content type %s <- readFilePart" contentType)
@@ -348,7 +348,7 @@ type ConnectionFacade(ctx) =
           | None ->
             return () 
 
-        | Choice2Of2 _ ->
+        | Choice1Of2 _ | Choice2Of2 _ ->
           use mem = new MemoryStream()
           let! a =
             readUntil (ASCII.bytes(eol + boundary)) (fun x y -> async {


### PR DESCRIPTION
According to http://www.faqs.org/rfcs/rfc2388.html can provide Content-Disposition without the filename attribute.

I don't know if this is a good solution, because the provided content type gets discarded.
Maybe the content type should be added to the multiPartFields list with a default of text/plain?