### PR TITLE
Workaround DotLiquid newline feed issue in test

### DIFF
--- a/src/Suave.Tests/DotLiquid.fs
+++ b/src/Suave.Tests/DotLiquid.fs
@@ -2,6 +2,7 @@
 
 open Fuchu
 open Suave
+open System
 open System.IO
 
 type M1 =
@@ -23,7 +24,7 @@ let tests =
       let subject =
         DotLiquid.renderPageFile (combine "liquid/child.liquid") { M1.name = "haf2" }
         |> Async.RunSynchronously
-      Assert.Equal("should render parent and child", "Parent\nHi haf2", subject)
+      Assert.Equal("should render parent and child", (sprintf "Parent%sHi haf2" Environment.NewLine) , subject)
 
     yield testCase "can render from string" <| fun () ->
       let subject =

--- a/src/Suave.Tests/DotLiquid.fs
+++ b/src/Suave.Tests/DotLiquid.fs
@@ -24,7 +24,7 @@ let tests =
       let subject =
         DotLiquid.renderPageFile (combine "liquid/child.liquid") { M1.name = "haf2" }
         |> Async.RunSynchronously
-      Assert.Equal("should render parent and child", (sprintf "Parent%sHi haf2" Environment.NewLine) , subject)
+      Assert.Equal("should render parent and child", "Parent: Hi haf2" , subject)
 
     yield testCase "can render from string" <| fun () ->
       let subject =

--- a/src/Suave.Tests/DotLiquid.fs
+++ b/src/Suave.Tests/DotLiquid.fs
@@ -2,7 +2,6 @@
 
 open Fuchu
 open Suave
-open System
 open System.IO
 
 type M1 =

--- a/src/Suave.Tests/liquid/parent.liquid
+++ b/src/Suave.Tests/liquid/parent.liquid
@@ -1,2 +1,1 @@
-﻿Parent
-{% block main %}{% endblock %}
+﻿Parent: {% block main %}{% endblock %}


### PR DESCRIPTION
One unit test fails on windows due to CRLF:

```
src\Suave.Tests\bin\Release\Suave.Tests.exe
OSVersion: Microsoft Windows NT 6.1.7601 Service Pack 1; running 64-bit process on 64-bit operating system.
Running tests with default TCP engine.
DotLiquid templating with Suave/can render a page & master: Failed:
should render parent and child
Expected: "Parent
Hi haf2"
Actual: "Parent
Hi haf2"
  c:\prg\Fuchu\Fuchu\Assertions.fs(13,1): <StartupCode$Fuchu>.$Assertions.Equal@13.Invoke(String msg)
 (00:00:00.0151109)
216 tests run: 215 passed, 1 ignored, 1 failed, 0 errored (00:00:04.0772271)
Done.
rake aborted!
Albacore::CommandFailedError: Command failed with status (1):
  src\Suave.Tests\bin\Release\Suave.Tests.exe
OSVersion: Microsoft Windows NT 6.1.7601 Service Pack 1; running 64-bit process on 64-bit operating system.
Running tests with default TCP engine.
DotLiquid templating with Suave/can render a page & master: Failed:
should render parent and child
Expected: "Parent
Hi haf2"
Actual: "Parent
Hi haf2"
  c:\prg\Fuchu\Fuchu\Assertions.fs(13,1): <StartupCode$Fuchu>.$Assertions.Equal@13.Invoke(String msg)
 (00:00:00.0151109)
216 tests run: 215 passed, 1 ignored, 1 failed, 0 errored (00:00:04.0772271)
Done.
C:/github/suave/Rakefile:222:in `block (2 levels) in <top (required)>'
Tasks: TOP => default => tests:unit => tests:unit_quick
(See full trace by running task with --trace)
```

The fix is to use `Environment.NewLine`.
I'm not sure however why AppVeyor didn't fail on that test.