### PR TITLE
Websocket multiple readers and writers

### DIFF
--- a/src/Suave/Sockets/TcpTransport.fs
+++ b/src/Suave/Sockets/TcpTransport.fs
@@ -30,10 +30,20 @@ type TcpTransport(acceptArgs     : SocketAsyncEventArgs,
 
   interface ITransport with
     member this.read (buf : ByteSegment) =
-      asyncDo acceptArgs.AcceptSocket.ReceiveAsync (setBuffer buf) (fun a -> a.BytesTransferred) readArgs
+      async{
+       if acceptArgs.AcceptSocket = null then
+         return Choice2Of2 (ConnectionError "read error: acceptArgs.AcceptSocket = null") 
+       else
+         return! asyncDo acceptArgs.AcceptSocket.ReceiveAsync (setBuffer buf) (fun a -> a.BytesTransferred) readArgs
+       }
 
     member this.write (buf : ByteSegment) =
-      asyncDo acceptArgs.AcceptSocket.SendAsync (setBuffer buf) ignore writeArgs
+      async{
+        if acceptArgs.AcceptSocket = null then
+         return Choice2Of2 (ConnectionError "write error: acceptArgs.AcceptSocket = null") 
+       else
+         return! asyncDo acceptArgs.AcceptSocket.SendAsync (setBuffer buf) ignore writeArgs
+      }
 
     member this.shutdown() = async {
       shutdownSocket ()

--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -9,6 +9,7 @@ module WebSocket =
   open Suave.Logging
 
   open System
+  open System.Collections.Concurrent
   open System.Security.Cryptography
   open System.Text
 
@@ -132,8 +133,17 @@ module WebSocket =
       }
     loop 0
 
+  type internal Cont<'t> = 't -> unit
+
+  open System.Threading
+
+  let fork f = ThreadPool.QueueUserWorkItem(WaitCallback(f)) |> ignore
+
   /// This class represents a WebSocket connection, it provides an interface to read and write to a WebSocket.
   type WebSocket(connection : Connection) =
+    
+    let mutable writing = false
+    let mutable reading = false
 
     let readExtendedLength header = socket {
       if header.length = 126 then
@@ -153,11 +163,31 @@ module WebSocket =
           return uint64(header.length)
       }
 
-    let sendFrame opcode bs fin = socket {
-      let frame = frame opcode bs fin
-      let! _ = connection.transport.write <| ArraySegment (frame,0,frame.Length)
-      return ()
+    let writeQueue = new ConcurrentQueue<byte[]*Cont<Choice<unit,Error>>>()
+    let readQueue  = new ConcurrentQueue<Cont<Choice<Opcode*byte[]*bool,Error>>>()
+
+    let rec writeloop _ =
+      async{
+        try
+          match writeQueue.TryDequeue() with
+          | true, (frame, ok) ->
+            let! res = connection.transport.write <| ArraySegment (frame,0,frame.Length)
+            fork (fun _ -> ok res)
+            do! writeloop ()
+          | false, _ ->
+            lock writeQueue (fun _ -> writing <- false)
+        with ex ->
+          lock writeQueue (fun _ -> writing <- false)
       }
+
+    let sendFrame opcode bs fin =
+      let frame = frame opcode bs fin
+      Async.FromContinuations <| fun (ok,ex,cn) ->
+        writeQueue.Enqueue (frame,ok)
+        lock(writeQueue) (fun _ -> 
+          if not writing then
+            writing <- true
+            Async.Start <| writeloop ())
 
     let readFrame () = socket {
       assert (List.length connection.segments = 0)
@@ -182,8 +212,29 @@ module WebSocket =
         return (header.opcode, data, header.fin)
       }
 
-    member this.read () = readFrame ()
-    member this.send opcode bs fin = sendFrame  opcode bs fin
+    let rec readloop _ =
+      async{
+        try
+          match readQueue.TryDequeue() with
+          | true, ok ->
+            let! res = readFrame ()
+            fork (fun _ -> ok res)
+            do! readloop ()
+          | false, _ ->
+            lock readQueue (fun _ -> reading <- false)
+        with ex ->
+          lock readQueue (fun _ -> reading <- false)
+      }
+
+    member this.read () =
+       Async.FromContinuations <| fun (ok,ex,cn) ->
+        readQueue.Enqueue (ok)
+        lock(readQueue) (fun _ -> 
+          if not reading then
+            reading <- true
+            Async.Start <| readloop ())
+
+    member this.send opcode bs fin = sendFrame opcode bs fin
 
   let internal handShakeAux webSocketKey continuation (ctx : HttpContext) =
     socket {


### PR DESCRIPTION
This PR attempts to solve #467

The issue is provoked because `SocketAsyncEventArgs` do not support overlapping read/write calls.

In this code we serialize consecutive read/write calls so they do not overlap.