### PR TITLE
fix for .net core sdk preview1

### DIFF
--- a/examples/Example/project.json
+++ b/examples/Example/project.json
@@ -23,7 +23,7 @@
 
   "tools": {
     "dotnet-compile-fsc": {
-      "version": "1.0.0-*",
+      "version": "1.0.0-preview1-*",
       "imports": [
         "dnxcore50",
         "portable-net45+win81",

--- a/src/Suave/project.json
+++ b/src/Suave/project.json
@@ -72,7 +72,7 @@
 
     "tools": {
         "dotnet-compile-fsc": {
-            "version": "1.0.0-*",
+            "version": "1.0.0-preview1-*",
             "imports": [
                 "dnxcore50",
                 "portable-net45+win81",


### PR DESCRIPTION
Some fixed, based on https://github.com/dotnet/netcorecli-fsc/wiki/.NET-Core-SDK-preview1#notes

This fix a minor mistake of `preview1`, and helps to not break build because works is in progress for `preview2` .

