### PR TITLE
dotliquid registerFiltersByName, options, arrays

### DIFF
--- a/src/Suave.DotLiquid/Library.fs
+++ b/src/Suave.DotLiquid/Library.fs
@@ -21,6 +21,7 @@ open Suave.Files
 /// Use the ruby naming convention by default
 do Template.NamingConvention <- RubyNamingConvention()
 
+
 module internal Impl =
 
   /// Represents a local file system relative to the specified 'root'
@@ -179,12 +180,14 @@ let page fileName model : WebPart =
 ///     do registerFiltersByName "MyFilters"
 ///
 let registerFiltersByName name =
-  let asm = Assembly.GetExecutingAssembly()
-  let typ =
-    [ for t in asm.GetTypes() do
-        if t.FullName.EndsWith(name) && not(t.FullName.Contains("<StartupCode")) then yield t ]
-    |> Seq.last
+  let asm = Assembly.GetEntryAssembly()
+  let typ = 
+    asm.GetTypes()
+    |> Array.find (fun t -> t.FullName.EndsWith(name) && 
+                            not(t.FullName.Contains("<StartupCode")))
   Template.RegisterFilter typ
+
+  
 
 /// Similar to `registerFiltersByName`, but the module is speicfied by its
 /// `System.Type` (This is more cumbersome, but safer alternative.)

--- a/src/Suave.DotLiquid/Library.fs
+++ b/src/Suave.DotLiquid/Library.fs
@@ -37,8 +37,8 @@ module internal Impl =
     let o = obj()
     fun f -> lock o f
 
-  /// Given a type which is an F# record containing seq<_>, list<_>, array<_> and other
-  /// records, register the type with DotLiquid so that its fields are accessible
+  /// Given a type which is an F# record containing seq<_>, list<_>, array<_>, option and 
+  /// other records, register the type with DotLiquid so that its fields are accessible
   let tryRegisterTypeTree =
     let registered = Dictionary<_, _>()
     let rec loop ty =
@@ -155,7 +155,8 @@ let renderPageFile fileFullPath (model : 'm) =
 
 /// Render a page using DotLiquid template. Takes a path (relative to the directory specified
 /// using `setTemplatesDir` and a value that is exposed as the "model" variable. You can use
-/// any F# record type, seq<_>, list<_>, and array<_> without having to explicitly register the fields.
+/// any F# record type, seq<_>, list<_>, and array<_>  and option without having to explicitly 
+/// register the fields.
 ///
 ///     type Page = { Total : int }
 ///     let app = page "index.html" { Total = 42 }


### PR DESCRIPTION
This fixes dotLiquid registerFiltersByName, such that it will search the users assembly instead of only the suave.DotLiquid.dll assembly, for modules of the name `name`. Also switched to a probably marginally more efficient search of the assemblies which is no less readable using Array.find

This also fixes array support, types within arrays are now properly registered. This was not working properly in my previous PR/

This also adds support for options, by registering the Value field you can use them in templates like so:

```html
{% for decoder in model.decoders %}  
  {% if decoder.Value %}               
    <option value="{{decoder.Value.x}}">{{decoder.Value.x}}</option>
  {% endif %}
{% endfor %}
```
