### PR TITLE
resolves #484 - adds support for sending ArraySegments of existing buffers

### DIFF
--- a/examples/WebSocket/Program.fs
+++ b/examples/WebSocket/Program.fs
@@ -24,11 +24,11 @@ let echo (webSocket : WebSocket) =
       match msg with
       | (Text, data, true) ->
         let str = UTF8.toString data
-        do! webSocket.send Text data true
+        do! webSocket.send Text (ArraySegment data) true
       | (Ping, _, _) ->
-        do! webSocket.send Pong [||] true
+        do! webSocket.send Pong (ArraySegment([||])) true
       | (Close, _, _) ->
-        do! webSocket.send Close [||] true
+        do! webSocket.send Close (ArraySegment([||])) true
         loop := false
       | _ -> ()
   }

--- a/src/Suave.Tests/WebSocket.fs
+++ b/src/Suave.Tests/WebSocket.fs
@@ -42,20 +42,20 @@ let websocketTests cfg =
           let str = UTF8.toString data
           match str with
           | "BinaryRequest7bit" ->  
-            let message = Array.create (int PayloadSize.Bit7) 0uy
+            let message = ArraySegment(Array.create (int PayloadSize.Bit7) 0uy)
             do! webSocket.send Binary message true
           | "BinaryRequest16bit" ->  
-            let message = Array.create (int PayloadSize.Bit16) 0uy
+            let message = ArraySegment(Array.create (int PayloadSize.Bit16) 0uy)
             do! webSocket.send Binary message true
           | "BinaryRequest32bit" ->  
-            let message = Array.create (int PayloadSize.Bit32) 0uy
+            let message = ArraySegment(Array.create (int PayloadSize.Bit32) 0uy)
             do! webSocket.send Binary message true
           | _ -> 
-            do! webSocket.send Text data true
+            do! webSocket.send Text (ArraySegment data) true
         | (Ping, _, _) ->
-          do! webSocket.send Pong [||] true
+          do! webSocket.send Pong (ArraySegment([||])) true
         | (Close, _, _) ->
-          do! webSocket.send Close [||] true
+          do! webSocket.send Close (ArraySegment([||])) true
           loop := false
         | _ -> ()
       }

--- a/src/Suave/Owin.fs
+++ b/src/Suave/Owin.fs
@@ -385,8 +385,7 @@ module OwinApp =
     let webSocketSendAsync (webSocket : WebSocket) =
       new WebSocketSendAsync(
         fun (data: ArraySegment<byte>) (messageType: int) fin ct -> 
-          let arr = Array.sub data.Array data.Offset data.Count
-          let send = webSocket.send (toOpcode (byte messageType)) arr fin
+          let send = webSocket.send (toOpcode (byte messageType)) data fin
           let task = Async.StartAsTask (send, TaskCreationOptions.None, ct)
           task :> Task)
 
@@ -409,7 +408,7 @@ module OwinApp =
       new WebSocketCloseAsync(
         fun closeStatus closeDescription ct -> 
           let close = async {
-            let! res = webSocket.send Close [||] true
+            let! res = webSocket.send Close (ByteSegment([||])) true
             return ()
           }
           Async.StartAsTask (close, TaskCreationOptions.None, ct) :> Task)


### PR DESCRIPTION
This allows the reuse of existing byte array buffers when sending messages via websockets. Some points to note:

- I have replaced the send member of the Websocket class in Websocket.fs as instructed to on the #484 issue.
- If I use the parameter-less constructor for ArraySegment's the LibUV tests cause seg fault native exceptions. This was under Mono 4.2. Using ArraySegment([||]) instead fixes this but feels a little unnatural and forced from an API perspective.