### PR TITLE
Dispose file streams when serving files

### DIFF
--- a/src/Suave/Compression.fs
+++ b/src/Suave/Compression.fs
@@ -101,16 +101,19 @@ module Compression =
         let enconding = parseEncoder ctx.request
         match enconding with
         | Some n ->
-          if Globals.compressedFilesMap.ContainsKey key then
-            let lastModified = getLast key
-            let cmprInfo = new FileInfo(Globals.compressedFilesMap.[key])
-            if lastModified > cmprInfo.CreationTime then
-              let! newPath = compressFile n stream compressionFolder
-              Globals.compressedFilesMap.[key] <- newPath
-          else
-            let! newPath =  compressFile n stream compressionFolder
-            Globals.compressedFilesMap.TryAdd(key,newPath) |> ignore
-          return Some n, new FileStream(Globals.compressedFilesMap.[key], FileMode.Open, FileAccess.Read, FileShare.Read) :> Stream
+          try
+            if Globals.compressedFilesMap.ContainsKey key then
+              let lastModified = getLast key
+              let cmprInfo = new FileInfo(Globals.compressedFilesMap.[key])
+              if lastModified > cmprInfo.CreationTime then
+                let! newPath = compressFile n stream compressionFolder
+                Globals.compressedFilesMap.[key] <- newPath
+            else
+              let! newPath =  compressFile n stream compressionFolder
+              Globals.compressedFilesMap.TryAdd(key,newPath) |> ignore
+            return Some n, new FileStream(Globals.compressedFilesMap.[key], FileMode.Open, FileAccess.Read, FileShare.Read) :> Stream
+          finally
+            stream.Dispose()
         | None ->
           return None, stream
       else

--- a/src/Suave/Compression.fs
+++ b/src/Suave/Compression.fs
@@ -89,7 +89,6 @@ module Compression =
     if not (Directory.Exists compressionFolder) then Directory.CreateDirectory compressionFolder |> ignore
     let newPath = Path.Combine(compressionFolder,tempFileName)
     do! compress n newPath stream
-    stream.Dispose()
     return newPath
   }
 


### PR DESCRIPTION
Opened file streams were not disposed when serving static files. This caused handle leaks on Windows.

To reproduce this issue, run Suave with configuration to serve static files.
Open any file served by Suave in a browser (it should have at least 500 bytes, so that response is compressed). Now press and hold key that reloads displayed page for a few seconds.

Then use Handle utility (or Process Explorer) where you can see that there are several opened handles
for the original file and also its compressed representation:
```
Handle v4.0
Copyright (C) 1997-2014 Mark Russinovich
Sysinternals - www.sysinternals.com

   ...  
  5D0: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
  6A0: File  (---)   C:\dev\suave\index.html
  6BC: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
  6C0: File  (---)   C:\dev\suave\index.html
  6C4: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
  7DC: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
  7E0: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
  7E4: File  (---)   C:\dev\suave\index.html
  7E8: File  (---)   C:\dev\suave\src\Suave\bin\Debug\_temporary_compressed_files\g5kv1sjy.n5n
 
```

After adding Dispose() calls, handles for the original file and its compressed representation are closed correctly.

