### PR TITLE
Add helper function for getting response status code for a request in Suave.Testing

### DIFF
--- a/src/Suave.Testing/Testing.fs
+++ b/src/Suave.Testing/Testing.fs
@@ -220,6 +220,9 @@ let reqHeaders methd resource data =
 let reqContentHeaders methd resource data =
   reqResp methd resource "" data None DecompressionMethods.None id contentHeaders
 
+let reqStatusCode methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id statusCode
+
 /// Test a request by looking at the cookies alone.
 let reqCookies methd resource data ctx =
   let cookies = new CookieContainer()


### PR DESCRIPTION
Small addition to Suave.Testing. I don't know if this helper function was missing due to an omission or if there is a reason for it but seems useful to me... :-)