### PR TITLE
Enhanced structured log messages

### DIFF
--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -1087,6 +1087,35 @@ module Filters =
   val clientHost : hostname:string -> WebPart
 
   /// <summary><para>
+  /// The structured version of default log format for <see cref="log" />.  NCSA Common log format
+  ///
+  /// 127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+  ///
+  /// A "-" in a field indicates missing data.
+  ///
+  /// 127.0.0.1 is the IP address of the client (remote host) which made the request to the server.
+  /// user-identifier is the RFC 1413 identity of the client.
+  /// frank is the userid of the person requesting the document.
+  /// [10/Oct/2000:13:55:36 -0700] is the date, time, and time zone when the server finished processing the request, by default in strftime format %d/%b/%Y:%H:%M:%S %z.
+  /// "GET /apache_pb.gif HTTP/1.0" is the request line from the client. The method GET, /apache_pb.gif the resource requested, and HTTP/1.0 the HTTP protocol.
+  /// 200 is the HTTP status code returned to the client. 2xx is a successful response, 3xx a redirection, 4xx a client error, and 5xx a server error.
+  /// 2326 is the size of the object returned to the client, measured in bytes.
+  /// </para></summary>
+  val logFormatStructured : ctx:HttpContext -> string * Map<string,obj>
+
+  /// <summary><para>
+  /// Log the HttpRequest to the given logger, given the Suave Logger, a LogLevel and a
+  /// message formatter that can inspect the context and produce a message to
+  /// send to the logger, along with the structured fields as a name*obj map.
+  /// </para></summary>
+  val logWithLevelStructured :  level:LogLevel -> logger:Logger -> messageFun:(HttpContext -> string * Map<string,obj>) -> WebPart
+
+  /// <summary><para>
+  /// The function log is equivalent to `logWithLevel LogLevel.Debug`.
+  /// </para></summary>
+  val logStructured : logger:Logger -> messageFun:(HttpContext -> string * Map<string,obj>) -> WebPart
+
+  /// <summary><para>
   /// The default log format for <see cref="log" />.  NCSA Common log format
   ///
   /// 127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326

--- a/src/Suave/Sockets/BufferManager.fs
+++ b/src/Suave/Sockets/BufferManager.fs
@@ -19,7 +19,7 @@ type BufferManager(totalBytes, bufferSize, autoGrow) =
 
   do logger.log Debug (
        Message.eventX "Initialising BufferManager with {totalBytes}"
-       >> Message.setFieldValue "size" totalBytes)
+       >> Message.setFieldValue "totalBytes" totalBytes)
 
   /// underlying list of byte arrays maintained by the Buffer Manager
   let segments = new ConcurrentBag<ArraySegment<byte>>()


### PR DESCRIPTION
The following are addressed:
 1. Fix buffer manager log message. It was setting a `size` field, with a template that required `{totalBytes}` (10611b4)
 1. Improve the 'listener started' log message structure, instead of formatting useful structured data as strings (via`StartData.ToString()`), we now separate out the parts into individual structured fields. (650e749)
 1. Add a structured log combinator, the same as the existing log combinator functions, only with the structured message format `template {prop}` and a `Map<string,obj>` for name/values to include in the structured log event. (b49afc4)
