### PR TITLE
Upgrade logging facade, coloured console output

### DIFF
--- a/examples/CORS/Program.fs
+++ b/examples/CORS/Program.fs
@@ -19,9 +19,9 @@ let logger = Targets.create Verbose
 let corsConfig = { defaultCORSConfig with allowedUris = InclusiveOption.Some [ "http://localhost:8085" ] }
 
 let app =
-    choose [ 
+    choose [
         GET >=> path "/hello" >=> cors corsConfig >=> OK "CORS request accepted."
-    ] >=> log logger logFormat
+    ] >=> logStructured logger logFormatStructured
 
 [<EntryPoint>]
 let main argv =

--- a/examples/Example/Program.fs
+++ b/examples/Example/Program.fs
@@ -45,7 +45,7 @@ let myApp =
 // typed routes
 let testApp =
   choose [
-    log logger logFormat >=> never
+    logStructured logger logFormatStructured >=> never
     pathScan "/add/%d/%d"   (fun (a,b) -> OK((a + b).ToString()))
     pathScan "/minus/%d/%d" (fun (a,b) -> OK((a - b).ToString()))
     pathScan "/divide/%d/%d" (fun (a,b) -> OK((a / b).ToString()))
@@ -195,7 +195,7 @@ let app =
           >=> OK "Doooooge"
         RequestErrors.NOT_FOUND "Found no handlers"
       ]
-    ] >=> log logger logFormat
+    ] >=> logStructured logger logFormatStructured
 
 (*
 // using Suave.OpenSSL

--- a/paket.lock
+++ b/paket.lock
@@ -13,7 +13,7 @@ GITHUB
   remote: haf/YoLo
     YoLo.fs (11023b9fcd2c1d28a7a0c0de5609647e3e1b03ce)
   remote: logary/logary
-    src/Logary.Facade/Facade.fs (6bbcf69be1712464e629499093921cf3293a6f70)
+    src/Logary.Facade/Facade.fs (a131dce06cd491e75db74b7c2467d84814d81200)
 GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2


### PR DESCRIPTION
This PR updates to the latest [Logary.Facade](https://github.com/logary/logary/#using-logary-in-a-library), which now uses a structured logging [coloured console theme](https://github.com/logary/logary/#console-logging) by default.

This screenshot shows what the [Example](https://github.com/SuaveIO/suave/blob/8d26c61fd00431f960b627c1be0a4e5e0badf6a4/examples/Example/Program.fs#L198) console output looks like after this change:

![image](https://cloud.githubusercontent.com/assets/570470/19339229/8da1c054-9165-11e6-97b5-141f5d9434b0.png)

Notice the structured values are highlighted (based on `Type`), making it easier to scan the output and spot the key values of interest.

