### PR TITLE
Place spaces between attributes

### DIFF
--- a/src/Experimental/Xml.fs
+++ b/src/Experimental/Xml.fs
@@ -90,29 +90,29 @@ let samplePage =
 
 /// Rendering
 
+let internal joinSpaces (strings:#seq<string>) =
+  String.Join (" ", strings)
+
+let internal attributesToString attributes =
+  attributes
+  |> Array.map (fun (a, b) -> sprintf "%s=\"%s\"" a b) 
+  |> joinSpaces
+
 let internal leafElementToString = function
  | Text text -> text
  | WhiteSpace text -> text
- | Element (e,id, attributes) ->
-   if Array.length attributes = 0 then
-     sprintf "<%s/>" e
-   else
-     let ats =
-       Array.map (fun (a,b) -> sprintf "%s=\"%s\"" a b) attributes
-       |> String.Concat
-     sprintf "<%s %s/>" e ats
+ | Element (e, id, attributes) ->
+   match attributes with
+   | [||] -> sprintf "<%s/>" e
+   | _ -> sprintf "<%s %s/>" e (attributes |> attributesToString)
 
 let internal beginElementToString = function
  | Text text -> failwith "invalid option"
  | WhiteSpace text -> failwith "invalid option"
- | Element (e,id, attributes) ->
-   if Array.length attributes = 0 then
-     sprintf "<%s>" e
-   else
-     let ats =
-       Array.map (fun (a,b) -> sprintf "%s=\"%s\"" a b) attributes
-       |> String.Concat
-     sprintf "<%s %s>" e ats
+ | Element (e, id, attributes) ->
+   match attributes with
+   | [||] -> sprintf "<%s>" e
+   | _ -> sprintf "<%s %s>" e (attributes |> attributesToString)
 
 let internal endElementToString = function
  | Text text -> failwith "invalid option"


### PR DESCRIPTION
The current code does not output spaces between attribute pairs. For example, it may output

<input type="submit"value="Submit"/>

Apparently browsers don't have a problem with this. I was surprised to learn that, but I assume that this is legal. However, it did cause a problem for me when I wrote some code to pretty-print Suave's output. I was trying to parse the result of xmlToString() with XDocument.Parse(), and that throws an exception when it encounters the two attribute pairs with no space between them.

In general, it would seem like a good idea to put spaces between attribute pairs, just for readability.