### PR TITLE
Update void elements in Suave.Html

### DIFF
--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -31,14 +31,14 @@ let div = tag "div"
 let p = tag "p"
 let a href attr = tag "a" (("href",href)::attr)
 let span = tag "span"
-let img attr = tag "img" attr []
-let input attr = tag "input" attr []
 
 // Void tags
 let link attr = voidTag "link" attr
 let meta attr = voidTag "meta" attr
 let hr attr = voidTag "hr" attr
 let br attr = voidTag "br" attr
+let img attr = voidTag "img" attr
+let input attr = voidTag "input" attr
 
 /// Example
 

--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -10,7 +10,7 @@ type Node =
   /// A regular html element that can contain a list of other nodes
   | Element of Element * Node list
   /// A void element is one that can't have content, like link, br, hr, meta
-  /// See: https://dev.w3.org/html5/html-author/#void
+  /// See: https://www.w3.org/TR/html5/syntax.html#void-elements
   | VoidElement of Element
   /// A text value for a node
   | Text of string

--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -9,7 +9,7 @@ type Element = string * Attribute[]
 type Node =
   /// A regular html element that can contain a list of other nodes
   | Element of Element * Node list
-  /// A void element is one that can't have content, like link, br, hr, meta
+  /// A void element is one that can't have content
   /// See: https://www.w3.org/TR/html5/syntax.html#void-elements
   | VoidElement of Element
   /// A text value for a node


### PR DESCRIPTION
According to the HTML5 spec, "img" and "input" are void elements:

https://www.w3.org/TR/html5/syntax.html#void-elements

They are currently defined using "tag" with empty content but using "voidTag" seems more appropriate.