### PR TITLE
Expand DotLiquid example.

### DIFF
--- a/docs/dotliquid.md
+++ b/docs/dotliquid.md
@@ -35,6 +35,19 @@ let app =
 
 {% endhighlight %}
 
+Then, for your template:
+
+{% highlight html %}
+<html>
+  <head>
+    <title>{{ model.title }}</title>
+  </head>
+  <body>
+    <p>Hello from {{ model.title }}!</p>
+  </body>
+</html>
+{% endhighlight %}
+
 
 References
 ----------


### PR DESCRIPTION
This change makes it clear that DotLiquid is given an object called "model," rather than a separate object for each of the fields in Model.