### PR TITLE
Replace Convert.ChangeType to unbox in StateStore.get

### DIFF
--- a/src/Suave/State.fs
+++ b/src/Suave/State.fs
@@ -93,8 +93,11 @@ module CookieStateStore =
     let private createStateStore (serialiser : CookieSerialiser) (userState : Map<string, obj>) (ss : obj) =
       { new StateStore with
           member x.get key =
-            serialiser.deserialise (ss :?> byte []) |> Map.tryFind key
-            |> Option.map (fun x -> Convert.ChangeType(x, typeof<'T>) :?> 'T)
+            ss 
+            :?> byte []
+            |> serialiser.deserialise
+            |> Map.tryFind key
+            |> Option.map unbox
           member x.set key value =
             let expiry = userState |> Map.find (StateStoreType + "-expiry") :?> CookieLife
             write expiry key value


### PR DESCRIPTION
I would like to be able to store any type in HttpContext.state, but the types that can be stored there must implement IConvertible, due to the call to Convert.ChangeType() in get(). Primitive types like string of course already implement this, but it's an onerous interface for user-defined types to have to implement.

However, get<'T> is already generic, and unbox<'T>works fine here. With the change, I am now able to store a record type, for example:

```
type User = {
    UserId: int
    Email: string
    Role: UserRole
}

// I can now store Session with no problem
type Session = 
    | Anonymous
    | AuthenticatedUser of User

```
I can't think of any reason not to make this change and lift the requirement for IConvertible.

(Note that I have left off the type parameter 'T because the current code does so, although readability is probably slightly better here with it).