### PR TITLE
Adding bindEmptyForm to bind forms without any predefined validations.

### DIFF
--- a/src/Experimental/Form.fs
+++ b/src/Experimental/Form.fs
@@ -144,7 +144,7 @@ let bindForm<'a> (form : Form<'a>) (req : HttpRequest) =
     return record
   }
 
-let bindForm2<'a> = 
+let bindEmptyForm<'a> = 
   let form : Form<'a> = Form([],[])
   bindForm form
 
@@ -278,7 +278,7 @@ type LoginCredentials = {
 
 Handler:
 let handleLogin req = 
-  match bindForm2 req with
+  match bindEmptyForm req with
   | Choice1Of2 loginCredentials -> 
     // ...
   | Choice2Of2 err -> 

--- a/src/Experimental/Form.fs
+++ b/src/Experimental/Form.fs
@@ -144,6 +144,10 @@ let bindForm<'a> (form : Form<'a>) (req : HttpRequest) =
     return record
   }
 
+let bindForm2<'a> = 
+  let form : Form<'a> = Form([],[])
+  bindForm form
+
 let maxLength max : Validation<string> =
   (fun s -> s.Length <= max),
   (sprintf "must be at most %d characters" max),
@@ -264,5 +268,21 @@ Binding.bindReq (bindForm register) handler BAD_REQUEST
 
 HTML markup:
 input (fun f -> <@ f.Password @>) [] register
+
+Plain Form binding
+
+type LoginCredentials = {
+  Username: string
+  Password : string
+}
+
+Handler:
+let handleLogin req = 
+  match bindForm2 req with
+  | Choice1Of2 loginCredentials -> 
+    // ...
+  | Choice2Of2 err -> 
+    // ...
+path "/login" >=> POST >=> request handleLogin
 
 *)


### PR DESCRIPTION
A syntactic sugar function to do model binding that doesn't need to use the predefined validations. I found it useful in cases where we rely on domain level validations. 