### PR TITLE
Fix Access-Control-Allow-Credentials casing

### DIFF
--- a/src/Suave.Tests/CORS.fs
+++ b/src/Suave.Tests/CORS.fs
@@ -67,7 +67,7 @@ let tests cfg =
           eq "Content" "" content // Preflight request should not return content
           eq "Access-Control-Allow-Origin header" origin (result.Headers.GetValues("Access-Control-Allow-Origin") |> Seq.head)
           eq "Access-Control-Allow-Methods header" "*" (result.Headers.GetValues("Access-Control-Allow-Methods") |> Seq.head)
-          eq "Access-Control-Allow-Credentials header" "True" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
+          eq "Access-Control-Allow-Credentials header" "true" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
 
         runWithConfig (composedApp None) |> reqResp HttpMethod.OPTIONS "/cors" "" None None DecompressionMethods.None setHeaders asserts
 
@@ -86,7 +86,7 @@ let tests cfg =
           eq "Content" "" content // Preflight request should not return content
           eq "Access-Control-Allow-Origin header" origin (result.Headers.GetValues("Access-Control-Allow-Origin") |> Seq.head)
           eq "Access-Control-Allow-Methods header" "*" (result.Headers.GetValues("Access-Control-Allow-Methods") |> Seq.head)
-          eq "Access-Control-Allow-Credentials header" "True" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
+          eq "Access-Control-Allow-Credentials header" "true" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
           eq "Access-Control-Allow-Headers header" allowedHeaders (result.Headers.GetValues("Access-Control-Allow-Headers") |> Seq.head)
 
         runWithConfig (composedApp None) |> reqResp HttpMethod.OPTIONS "/cors" "" None None DecompressionMethods.None setHeaders asserts
@@ -105,10 +105,25 @@ let tests cfg =
           eq "Content" "" content // Preflight request should not return content
           eq "Access-Control-Allow-Origin header" origin (result.Headers.GetValues("Access-Control-Allow-Origin") |> Seq.head)
           eq "Access-Control-Allow-Methods header" "*" (result.Headers.GetValues("Access-Control-Allow-Methods") |> Seq.head)
-          eq "Access-Control-Allow-Credentials header" "True" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
+          eq "Access-Control-Allow-Credentials header" "true" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
           eq "Access-Control-Max-Age header" "3600" (result.Headers.GetValues("Access-Control-Max-Age") |> Seq.head)
 
-        runWithConfig (composedApp (Some (cors corsConfig))) |> reqResp HttpMethod.OPTIONS "/cors" "" None None DecompressionMethods.None setHeaders asserts ]
+        runWithConfig (composedApp (Some (cors corsConfig))) |> reqResp HttpMethod.OPTIONS "/cors" "" None None DecompressionMethods.None setHeaders asserts
+        
+      testCase "Can make valid preflight CORS request - doesn't contain header when cookies aren't allowed" <| fun _ ->
+        
+        let corsConfig = { defaultCORSConfig with allowCookies = false }
+
+        let setHeaders (request : HttpRequestMessage) =
+          request.Headers.Add("Origin", origin)
+          request
+
+        let asserts (result : HttpResponseMessage) =
+          eq "Access-Control-Allow-Credentials header" false (result.Headers.Contains("Access-Control-Allow-Credentials"))
+
+        runWithConfig (composedApp (Some(cors corsConfig))) |> reqResp HttpMethod.OPTIONS "/cors" "" None None DecompressionMethods.None setHeaders asserts
+      ]
+
     testList "Actual requests tests" [
       testCase "Can make valid CORS request with default CORS config" <| fun _ ->
 
@@ -122,7 +137,7 @@ let tests cfg =
           eq "Content" "Success" content
           eq "Access-Control-Allow-Origin header" origin (result.Headers.GetValues("Access-Control-Allow-Origin") |> Seq.head)
           eq "Access-Control-Allow-Methods header" "*" (result.Headers.GetValues("Access-Control-Allow-Methods") |> Seq.head)
-          eq "Access-Control-Allow-Credentials header" "True" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
+          eq "Access-Control-Allow-Credentials header" "true" (result.Headers.GetValues("Access-Control-Allow-Credentials") |> Seq.head)
 
         runWithConfig (composedApp None) |> reqResp HttpMethod.GET "/cors" "" None None DecompressionMethods.None setHeaders asserts
 

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -858,7 +858,10 @@ module CORS =
       Writers.setHeader AccessControlMaxAge (age.ToString())
 
   let private setAllowCredentialsHeader config =
-    Writers.setHeader AccessControlAllowCredentials (config.allowCookies.ToString())
+    if config.allowCookies then
+        Writers.setHeader AccessControlAllowCredentials "true"
+    else
+        succeed
 
   let private setAllowMethodsHeader config value =
     match config.allowedMethods with


### PR DESCRIPTION
According to [the specification](https://www.w3.org/TR/cors/#http-access-control-allow-credentials) this header can only have one valid value: 'true' (Lower case).

>     Access-Control-Allow-Credentials: "Access-Control-Allow-Credentials" ":" true
>     true: %x74.72.75.65 ; "true", case-sensitive

The correct value is now emitted when allowCookies is set and the header omitted otherwise.

Chrome is now checking this header and consider the current values emitted by Suave as invalid (And so refuse all XHR connections)
