### PR TITLE
Allow further customising the console output

### DIFF
--- a/examples/Example/Program.fs
+++ b/examples/Example/Program.fs
@@ -17,7 +17,19 @@ open Suave.State.CookieStateStore
 let basicAuth =
   Authentication.authenticateBasic ((=) ("foo", "bar"))
 
-let logger = Targets.create Verbose [||]
+// This demonstrates how to customise the console logger output.
+// In most cases you wont need this. Instead you can use the more succinct: 
+// `let logger = Targets.create Verbose [||]`
+let loggingOptions =
+  { Literate.LiterateOptions.create() with
+      getLogLevelText = function Verbose->"V" | Debug->"D" | Info->"I" | Warn->"W" | Error->"E" | Fatal->"F" }
+
+let logger = LiterateConsoleTarget(
+                name = [|"Suave";"Examples";"Example"|],
+                minLevel = Verbose,
+                options = loggingOptions,
+                outputTemplate = "[{level}] {timestampUtc:o} {message} [{source}]{exceptions}"
+              ) :> Logger
 
 ///  With this workflow you can write WebParts like this
 let task : WebPart =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ nuget DotLiquid
 nuget RazorEngine
 
 github haf/YoLo YoLo.fs
-github logary/logary src/Logary.Facade/Facade.fs
+github logary/logary:c70468f60602e1ab954a38e574b946d4ffbda11d src/Logary.Facade/Facade.fs
 
 group Build
   source https://nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -11,7 +11,7 @@ GITHUB
   remote: haf/YoLo
     YoLo.fs (76e16a4c9338c2f04cb067add0e3a33b42a0f396)
   remote: logary/logary
-    src/Logary.Facade/Facade.fs (8fe3fce3f7d2602f2a4dc27419edfbce09c28a82)
+    src/Logary.Facade/Facade.fs (c70468f60602e1ab954a38e574b946d4ffbda11d)
 GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2
@@ -196,7 +196,6 @@ NUGET
       System.AppContext (>= 4.1)
       System.Collections (>= 4.0.11)
       System.Collections.Concurrent (>= 4.0.12)
-      System.Collections.Immutable (>= 1.1.37)
       System.Collections.Immutable (>= 1.2)
       System.Console (>= 4.0)
       System.Diagnostics.Debug (>= 4.0.11)
@@ -210,7 +209,6 @@ NUGET
       System.Linq (>= 4.1)
       System.Linq.Expressions (>= 4.1)
       System.Reflection (>= 4.1)
-      System.Reflection.Metadata (>= 1.2)
       System.Reflection.Metadata (>= 1.3)
       System.Reflection.Primitives (>= 4.0.1)
       System.Resources.ResourceManager (>= 4.0.1)


### PR DESCRIPTION
This bumps the Logary.Facade version to the latest. See logary/logary#234 for changes.

Using the new `LiterateConsoleTarget` ctor, with the `outputTemplate` parameter, one can configure the console output in a way that is very similar to what older versions of Suave supported:
<img width="1110" alt="screen shot 2017-02-10 at 12 09 24" src="https://cloud.githubusercontent.com/assets/570470/22811562/4d44a34e-ef8b-11e6-8fb7-617804f1bd03.png">

Notably, until now, it was not possible to render the log event `[{source}]`.