### PR TITLE
Basic authentication: support asynchronous authentication check

### DIFF
--- a/src/Suave/Authentication.fs
+++ b/src/Suave/Authentication.fs
@@ -22,17 +22,25 @@ let internal parseAuthenticationToken (token : string) =
 
 let inline private addUserName username ctx = { ctx with userState = ctx.userState |> Map.add UserNameKey (box username) }
 
-let authenticateBasic f (protectedPart : WebPart) (ctx : HttpContext) =
+let authenticateBasicAsync f protectedPart ctx =
   let p = ctx.request
   match p.header "authorization" with
   | Choice1Of2 header ->
     let (typ, username, password) = parseAuthenticationToken header
-    if (typ.Equals("basic")) && f (username, password) then
-      protectedPart (addUserName username ctx)
-    else
-      challenge (addUserName username ctx)
+    if (typ.Equals("basic")) then
+      async {
+        let! authenticated = f (username, password)
+        if authenticated then
+          return! protectedPart (addUserName username ctx)
+        else
+          return! challenge (addUserName username ctx)
+      }
+    else challenge (addUserName username ctx)
   | Choice2Of2 _ ->
     challenge ctx
+
+let authenticateBasic f protectedPart ctx = 
+  authenticateBasicAsync (f >> async.Return) protectedPart ctx
 
 module internal Utils =
   /// Generates a string key from the available characters with the given key size

--- a/src/Suave/Authentication.fsi
+++ b/src/Suave/Authentication.fsi
@@ -21,6 +21,17 @@ val UserNameKey : string
 /// </remarks>
 val authenticateBasic : f:(string * string -> bool) -> protectedPart:WebPart -> WebPart
 
+/// <summary><para>
+/// Perform basic authentication on the request, applying an asynchronous
+/// predicate to check the request for authentication tokens such as 
+/// 'username' and 'password'. Otherwise, if failing, challenge the client again.
+/// </para><para>
+/// </para><para>
+/// </para></summary>
+/// <remarks>
+/// </remarks>
+val authenticateBasicAsync : f:(string * string -> bool Async) -> protectedPart:WebPart -> WebPart
+
 val SessionAuthCookie : string
 
 /// The key used in `context.user_state` to save the session id for downstream


### PR DESCRIPTION
Basic authentication would commonly require IO - e.g. to look up a password hash in a database by username (this is my motivating use case). The `authenticateBasic` function only provides the ability to authenticate a (username, password) tuple by a simple blocking call. This PR adds an `authenticateBasicAsync` function which takes a non-blocking password check function instead.