### PR TITLE
fix clean checkout build to use Logary.Facade instead of Suave.Logging

### DIFF
--- a/examples/Asp.NET/Program.fs
+++ b/examples/Asp.NET/Program.fs
@@ -1,6 +1,6 @@
 ﻿
 open Suave
-open Suave.Logging
+open Logary.Facade
 open System.IO
 open System.Net
 

--- a/examples/CORS/Program.fs
+++ b/examples/CORS/Program.fs
@@ -4,7 +4,7 @@ open System
 open System.Net
 
 open Suave
-open Suave.Logging
+open Logary.Facade
 open Suave.Filters
 open Suave.Writers
 open Suave.Files

--- a/examples/Example/Program.fs
+++ b/examples/Example/Program.fs
@@ -5,7 +5,7 @@ open System.Net
 
 open Suave
 open Suave.Sockets.Control
-open Suave.Logging
+open Logary.Facade
 open Suave.Operators
 open Suave.EventSource
 open Suave.Filters

--- a/examples/Freya/Program.fs
+++ b/examples/Freya/Program.fs
@@ -48,7 +48,7 @@ module SampleApp =
 module SelfHostedServer =
   open Freya.Core
   open Suave
-  open Suave.Logging
+  open Logary.Facade
   open Suave.Owin
   open SampleApp
 

--- a/examples/IdentityServerIntegration/IdentityServer.fs
+++ b/examples/IdentityServerIntegration/IdentityServer.fs
@@ -6,8 +6,8 @@ module IdentityServer =
   open Owin
   open Microsoft.Owin.Builder
   open Suave
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
   open Suave.Owin
   open Suave.Filters
   open Suave.Operators

--- a/examples/Load/Program.fs
+++ b/examples/Load/Program.fs
@@ -6,7 +6,7 @@ open Suave.Operators
 open Suave.Http
 open Suave.Filters
 open Suave.Files
-open Suave.Logging
+open Logary.Facade
 
 let logger = Targets.create Verbose [||]
 

--- a/examples/WebSocket/Program.fs
+++ b/examples/WebSocket/Program.fs
@@ -6,7 +6,7 @@ open Suave.Filters
 open Suave.Successful
 open Suave.Files
 open Suave.RequestErrors
-open Suave.Logging
+open Logary.Facade
 open Suave.Utils
 
 open System

--- a/paket-files/logary/logary/src/Logary.Facade/Facade.fs
+++ b/paket-files/logary/logary/src/Logary.Facade/Facade.fs
@@ -2,7 +2,7 @@
 /// library. See https://github.com/logary/logary for details. This module is
 /// completely stand-alone in that it has no external references and its adapter
 /// in Logary has been well tested.
-namespace Suave.Logging
+namespace Logary.Facade
 
 open System
 open System.Runtime.CompilerServices

--- a/src/Suave.LibUv/Tcp.fs
+++ b/src/Suave.LibUv/Tcp.fs
@@ -127,7 +127,7 @@ type WriteOp() =
 
 type OperationPair = ReadOp*WriteOp
 
-open Suave.Logging
+open Logary.Facade
 
 type LibUvTransport(pool : ConcurrentPool<OperationPair>,
                     loop : IntPtr,
@@ -210,8 +210,8 @@ let bindSocket server bindCallback=
   if r<>0 then
     failwith ("Listen error: " + (new string(uv_strerror(r))))
 
-open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Http
 open Suave.Tcp
 open Suave

--- a/src/Suave.Testing/Testing.fs
+++ b/src/Suave.Testing/Testing.fs
@@ -30,8 +30,8 @@ open System.Net.Http
 open System.Net.Http.Headers
 open Expecto
 open Suave
-open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Http
 
 [<AutoOpen>]

--- a/src/Suave.Tests/Auth.fs
+++ b/src/Suave.Tests/Auth.fs
@@ -6,8 +6,8 @@ open System.Net
 open System.Net.Http
 open Expecto
 open Suave
-open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Cookie
 open Suave.State.CookieStateStore
 open Suave.Operators

--- a/src/Suave.Tests/CORS.fs
+++ b/src/Suave.Tests/CORS.fs
@@ -9,7 +9,7 @@ open Suave
 open Suave.Successful
 open Suave.Operators
 open Suave.Filters
-open Suave.Logging
+open Logary.Facade
 open Suave.Cookie
 open Suave.State.CookieStateStore
 open Suave.CORS

--- a/src/Suave.Tests/Cookie.fs
+++ b/src/Suave.Tests/Cookie.fs
@@ -2,7 +2,7 @@
 
 open Suave
 open Suave.Cookie
-open Suave.Logging
+open Logary.Facade
 open Suave.Testing
 
 open Expecto

--- a/src/Suave.Tests/LogLevel.fs
+++ b/src/Suave.Tests/LogLevel.fs
@@ -1,7 +1,7 @@
 ﻿module Suave.Tests.LogLevel
 
 open Suave
-open Suave.Logging
+open Logary.Facade
 open Suave.Testing
 open Expecto
 open FsCheck

--- a/src/Suave.Tests/Logger.fs
+++ b/src/Suave.Tests/Logger.fs
@@ -1,7 +1,7 @@
 ﻿module Suave.Tests.Logger
 
 open Suave
-open Suave.Logging
+open Logary.Facade
 open Suave.Testing
 open Expecto
 open FsCheck

--- a/src/Suave.Tests/Program.fs
+++ b/src/Suave.Tests/Program.fs
@@ -2,7 +2,7 @@ module Suave.Tests.Program
 
 open Suave.Http
 open Suave.Web
-open Suave.Logging
+open Logary.Facade
 open Suave.LibUv
 open ExpectoExtensions
 

--- a/src/Suave.Tests/TestUtilities.fs
+++ b/src/Suave.Tests/TestUtilities.fs
@@ -11,7 +11,7 @@ open System.Net.Http.Headers
 open System.Reflection
 open Suave
 open Suave.Web
-open Suave.Logging
+open Logary.Facade
 open Expecto
 open FsCheck
 

--- a/src/Suave/Authentication.fs
+++ b/src/Suave/Authentication.fs
@@ -5,7 +5,8 @@ open System.Text
 open Suave.RequestErrors
 open Suave.Utils
 open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Cookie
 open Suave.State.CookieStateStore
 open Suave.Operators

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -283,7 +283,7 @@ module ServerErrors =
 module Filters =
   open Suave.Utils
   open Suave.Utils.AsyncExtensions
-  open Suave.Logging
+  open Logary.Facade
   open System
   open System.Text.RegularExpressions
 
@@ -372,7 +372,7 @@ module Filters =
         level         = level
         name          = [| "Suave"; "Http"; "requests" |]
         fields        = Map.empty
-        timestamp     = Suave.Logging.Global.timestamp() })
+        timestamp     = Logary.Facade.Global.timestamp() })
     |> Async.map (fun () -> Some ctx)
 
   let logWithLevelStructured (level : LogLevel) (logger : Logger) (templateAndFieldsCreator : HttpContext -> (string * Map<string,obj>)) (ctx : HttpContext) =
@@ -382,7 +382,7 @@ module Filters =
         level         = level
         name          = [| "Suave"; "Http"; "requests" |]
         fields        = fields
-        timestamp     = Suave.Logging.Global.timestamp() })
+        timestamp     = Logary.Facade.Global.timestamp() })
     |> Async.map (fun () -> Some ctx)
 
   let logStructured (logger : Logger) (structuredFormatter : HttpContext -> (string * Map<string,obj>)) =
@@ -431,8 +431,8 @@ module ServeResource =
   open Redirection
   open RequestErrors
   open Suave.Utils
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
 
   // If a response includes both an Expires header and a max-age directive,
   // the max-age directive overrides the Expires header, even if the Expires header is more restrictive
@@ -479,8 +479,8 @@ module Files =
   open System.Text
 
   open Suave.Utils
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
   open Suave.Sockets.Control
 
   open Response

--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -1,6 +1,7 @@
 ﻿namespace Suave
 
 open Suave.Sockets
+open Logary.Facade
 
 /// <summary><para>
 /// The HTTP module has these main sub-modules:

--- a/src/Suave/ConnectionFacade.fs
+++ b/src/Suave/ConnectionFacade.fs
@@ -7,11 +7,12 @@ open System.IO
 open System.Collections.Generic
 open System.Net.Sockets
 
+open Logary.Facade
+open Logary.Facade.Message
 open Suave
+open Suave.Logging
 open Suave.Utils
 open Suave.Utils.Parsing
-open Suave.Logging
-open Suave.Logging.Message
 open Suave.Sockets
 open Suave.Sockets.Connection
 open Suave.Sockets.Control

--- a/src/Suave/Cookie.fs
+++ b/src/Suave/Cookie.fs
@@ -6,8 +6,8 @@ module Cookie =
   open System.Text
   open System.Globalization
   open Suave.Operators
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
   open Suave.Utils
 
   type CookieLife =

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -9,6 +9,7 @@ module Http =
   open System.Net.Sockets
   open System.Net
   open System.Text
+  open Logary.Facade
   open Suave.Utils
   open Suave.Utils.Aether
   open Suave.Utils.Aether.Operators

--- a/src/Suave/Http.fsi
+++ b/src/Suave/Http.fsi
@@ -7,6 +7,7 @@ module Http =
   open System.Net
   open Suave.Utils
   open Suave.Logging
+  open Logary.Facade
   open Suave.Sockets
 
   /// These are the known HTTP methods. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html

--- a/src/Suave/Owin.fs
+++ b/src/Suave/Owin.fs
@@ -18,7 +18,8 @@ open System.Runtime.InteropServices
 
 open Suave.Operators
 open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Sockets
 open Suave.Utils
 

--- a/src/Suave/ParsingAndControl.fs
+++ b/src/Suave/ParsingAndControl.fs
@@ -23,8 +23,8 @@ module internal ParsingAndControl =
   open Suave.Utils
   open Suave.Utils.Bytes
   open Suave.Utils.Parsing
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
 
   /// Free up a list of buffers
   let inline free context connection =

--- a/src/Suave/Sockets/BufferManager.fs
+++ b/src/Suave/Sockets/BufferManager.fs
@@ -4,7 +4,7 @@ open System
 open System.Collections.Generic
 open System.Collections.Concurrent
 open Suave
-open Suave.Logging
+open Logary.Facade
 
 /// This class creates a single large buffer which can be divided up
 /// and assigned to SocketAsyncEventArgs objects for use with each

--- a/src/Suave/State.fs
+++ b/src/Suave/State.fs
@@ -2,8 +2,8 @@ module Suave.State
 
 open Suave.Utils
 open Suave.Cookie
-open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 
 /// A session store is a reader and a writer function pair keyed on strings.
 type StateStore =

--- a/src/Suave/SuaveConfig.fs
+++ b/src/Suave/SuaveConfig.fs
@@ -1,6 +1,6 @@
 ﻿namespace Suave
 
-open Suave.Logging
+open Logary.Facade
 open Suave.Utils
 open System
 

--- a/src/Suave/Tcp.fs
+++ b/src/Suave/Tcp.fs
@@ -5,8 +5,8 @@ open System.Collections.Generic
 open System.Threading
 open System.Net
 open System.Net.Sockets
-open Suave.Logging
-open Suave.Logging.Message
+open Logary.Facade
+open Logary.Facade.Message
 open Suave.Sockets
 open Suave.Utils
 

--- a/src/Suave/Web.fs
+++ b/src/Suave/Web.fs
@@ -7,8 +7,8 @@ module Web =
   open System.IO
   open System.Net
   open Suave.Utils
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
 
   /// The default error handler returns a 500 Internal Error in response to
   /// thrown exceptions.

--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -6,8 +6,8 @@ module WebSocket =
   open Suave.Sockets.Control
   open Suave.Operators
   open Suave.Utils
-  open Suave.Logging
-  open Suave.Logging.Message
+  open Logary.Facade
+  open Logary.Facade.Message
 
   open System
   open System.Collections.Concurrent


### PR DESCRIPTION
Currently when you checkout Suave the build fails due to the change in namespace of Facade.fs.

Considering this is upgraded to be more generic (Logary.Facade) vs (Suave.Logging) - I'm guessing the intention was to port Suave to a more generic facade that can be used by multiple projects. So I've changed Suave's logging to the new namespace in this PR.

Afterwards the repo builds on a clean checkout which is important for doing any other open source PRs.