### PR TITLE
allow reuse of byte buffer when reading from a websocket

### DIFF
--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -88,6 +88,13 @@ module WebSocket =
     Data: ByteSegment
     }
 
+  type ByteSegmentCapacityException(requiredCapacity: int, actualCapacity: int) =
+    inherit Exception(
+      sprintf 
+        "Byte segment provided to read websocket message does not have enough capacity [Required Capacity: %i, Actual Capacity: %i]" 
+        requiredCapacity 
+        actualCapacity)
+
   let internal exctractHeader (arr: byte []) =
     let bytes x = arr.[x]
     let firstByte = bytes 0
@@ -135,6 +142,18 @@ module WebSocket =
         return arr
       else
         let! read = transport.read <| ArraySegment(arr,i,n - i)
+        return! loop (i+read)
+      }
+    loop 0
+
+  let readBytesIntoByteSegment retrieveByteSegment (transport : ITransport) (n : int) =
+    let byteSegment: ByteSegment = retrieveByteSegment n
+    if byteSegment.Count < n then raise (ByteSegmentCapacityException(n, byteSegment.Count))
+    let rec loop i = socket {
+      if i = n then
+        return byteSegment
+      else
+        let! read = transport.read <| ArraySegment(byteSegment.Array,(byteSegment.Offset + i), n - i)
         return! loop (i+read)
       }
     loop 0
@@ -204,7 +223,46 @@ module WebSocket =
         return (header.opcode, data, header.fin)
       }
 
-    member this.read () = runAsyncWithSemaphore readSemaphore (readFrame())
+    let readFrameIntoSegment (byteSegmentForLengthFunc: int -> ByteSegment) = socket {
+      assert (List.length connection.segments = 0)
+      let! arr = readBytes connection.transport 2
+      let header = exctractHeader arr
+      let! extendedLength = readExtendedLength header
+
+      assert(header.hasMask)
+      let! mask = readBytes connection.transport 4
+
+      if extendedLength > uint64 Int32.MaxValue then
+        let reason = sprintf "Frame size of %d bytes exceeds maximum accepted frame size (2 GB)" extendedLength
+        let data =
+            [| yield! BitConverter.GetBytes (CloseCode.CLOSE_TOO_LARGE.code)
+               yield! UTF8.bytes reason |]
+        do! sendFrame Close (ArraySegment(data)) true
+        return! SocketOp.abort (InputDataError(None, reason))
+      else
+        let! frame = readBytesIntoByteSegment byteSegmentForLengthFunc connection.transport (int extendedLength)
+        
+        // Messages from the client MUST be masked
+        if header.hasMask 
+        then
+          for i = 0 to (int extendedLength) - 1 do
+            let pos = frame.Offset + i
+            frame.Array.[pos] <- frame.Array.[pos] ^^^ mask.[i % 4]
+
+        return (header.opcode, frame, header.fin)
+      }
+    
+    member this.read () = async {
+      let! result = runAsyncWithSemaphore readSemaphore (readFrameIntoSegment (Array.zeroCreate >> ArraySegment))
+      return
+        match result with 
+        | Choice1Of2(opcode, frame, header) -> Choice1Of2(opcode, frame.Array, header)
+        | Choice2Of2(error) -> Choice2Of2(error)
+        }
+    
+    /// Reads from the websocket and puts the data into a ByteSegment selected by the byteSegmentForLengthFunc parameter
+    /// <param name="byteSegmentForLengthFunc">A function that takes in the message length in bytes required to hold the next websocket message and returns an appropriately sized ArraySegment of bytes</param>
+    member this.readIntoByteSegment byteSegmentForLengthFunc = runAsyncWithSemaphore readSemaphore (readFrameIntoSegment byteSegmentForLengthFunc)
 
     member this.send opcode bs fin = sendFrame opcode bs fin
 

--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -147,8 +147,14 @@ module WebSocket =
     loop 0
 
   let readBytesIntoByteSegment retrieveByteSegment (transport : ITransport) (n : int) =
-    let byteSegment: ByteSegment = retrieveByteSegment n
-    if byteSegment.Count < n then raise (ByteSegmentCapacityException(n, byteSegment.Count))
+    let byteSegmentRetrieved: ByteSegment = retrieveByteSegment n
+
+    let byteSegment = 
+        match byteSegmentRetrieved.Count with
+        | count when count = n -> byteSegmentRetrieved
+        | count when count < n -> raise (ByteSegmentCapacityException(n, byteSegmentRetrieved.Count))
+        | _ -> ArraySegment(byteSegmentRetrieved.Array, byteSegmentRetrieved.Offset, n)
+
     let rec loop i = socket {
       if i = n then
         return byteSegment


### PR DESCRIPTION
As part of https://github.com/SuaveIO/suave/pull/485 in order to decrease large object heap fragmentation I added our code to reuse byte buffers for sending to avoid memory pressure we experienced on our servers. However I didn't get around to putting up a PR for the reading side meaning the API for reading/writing currently doesn't match well.

This PR has two points: 

- Allows you to provide your own byte segment for reading via a function. There was a number of ways to do this and I'm open to feedback here on other methods (e.g allow use to provide a stream instead, using the BufferManager and exploiting the fin flag to get the user to keep reading, method returns a stream the user disposes, etc). The heart of the issue is that you don't know the length in advance before reading. 
- Avoid another allocation arrays when applying the mask.

I've added another method since I'm assuming we are respecting SemVer here and probably don't want to break the API now that v2 is released. I haven't changed array allocations for the headers and such since these arrays are typically small and won't make it to the LOH.