### PR TITLE
Minor Range content fixes

### DIFF
--- a/src/Suave/Compression.fs
+++ b/src/Suave/Compression.fs
@@ -92,10 +92,9 @@ module Compression =
     return newPath
   }
 
-  let transformStream (key : string) (getData : string -> Stream) (getLast : string -> DateTime)
+  let transformStream (key : string) (stream : Stream) (getLast : string -> DateTime)
                       compression compressionFolder ctx =
     socket {
-      let stream = getData key
       if compression && stream.Length > int64(MIN_BYTES_TO_COMPRESS) && stream.Length < int64(MAX_BYTES_TO_COMPRESS) then
         let enconding = parseEncoder ctx.request
         match enconding with


### PR DESCRIPTION
Fixes for #596 and #597 also returns 206 for partial content rather than 200 (I don't think most clients care as long as you're in the the 2XX range but it is in the spec). I don't know if it is bad to move the Stream creation outside of the Socket but I've ran it locally it seems to work the same as before.