### PR TITLE
Html.fs: HTML-encode attribtue values & text of elements

### DIFF
--- a/src/Experimental/Html.fs
+++ b/src/Experimental/Html.fs
@@ -1,6 +1,7 @@
-module Suave.Html
+﻿module Suave.Html
 
 open System
+open System.Net
 
 type Attribute = string * string
 
@@ -69,14 +70,14 @@ let rec htmlToString node =
     | xs ->
       let attributeString =
         attributes
-        |> Array.map (fun (k,v) -> sprintf " %s=\"%s\"" k v)
+        |> Array.map (fun (k, v) -> sprintf " %s=\"%s\"" k (WebUtility.HtmlEncode v))
         |> String.Concat
       sprintf "<%s%s>" e attributeString
 
   let endElemToString (e, _) = sprintf "</%s>" e
 
   match node with
-  | Text text -> text
+  | Text text -> text |> WebUtility.HtmlEncode
   | WhiteSpace text -> text
   | Element (e, nodes) ->
     let inner = nodes |> List.map htmlToString |> String.Concat


### PR DESCRIPTION
This PR encode attribute values and text of elements in `Html.fs`.

Example of invalid HTML before this PR:

```
> p ["title", "\"foo\" and \"bar\""] (text "foo & bar ") |> htmlToString;;
val it : string = "<p title=""foo" and "bar"">foo & bar </p>"
```

Correct encoding after applying this PR:

```
> p ["title", "\"foo\" and \"bar\""] (text "foo & bar ") |> htmlToString;;
val it : string = "<p title="&quot;foo&quot; and &quot;bar&quot;">foo &amp; bar </p>"
```
