### PR TITLE
Fix API doc generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -274,9 +274,7 @@ namespace :docs do
   end
 
   task :reference => :restore_paket do
-    # Last worked in 0a0851f
-    # 'System.Exception: Failed to escape text properly: []'
-    #system 'packages/docs/FsLibTool/tools/FsLibTool.exe', %W|src docs/_site|, clr_command: true
+    system 'packages/docs/FsLibTool/tools/FsLibTool.exe', %W|src docs/_site|, clr_command: true
     puts "Reference docs generated successfully."
   end
 

--- a/src/Experimental/Xml.fs
+++ b/src/Experimental/Xml.fs
@@ -27,7 +27,7 @@ let text s = Xml([Text s, Xml[]])
 let emptyText = text ""
 
 /// HTML elements.
-/// If you need to pass attributes use the version sufixed by ` (funny quote symbol)
+/// If you need to pass attributes use the version sufixed by Attr
 
 /// Flattens an XML list
 let flatten xs = xs |> List.map (fun (Xml y) -> y) |> List.concat |> Xml

--- a/src/Suave/Http.fsi
+++ b/src/Suave/Http.fsi
@@ -206,7 +206,7 @@ module Http =
     /// - `?flag=false` => `false`
     /// - `?flag=apa` => `false`
     /// - `?flag=true` => `true`
-    /// - `?` => `false
+    /// - `?` => `false`
     member queryFlag : flag:string -> bool
 
     /// Gets the header for the given key in the HttpRequest


### PR DESCRIPTION
Mismatched backtick in Http.fsi (introduced in commit bb77909829ceeb735a76bc75e8937368533c29dc) was causing API docs to fail.