### PR TITLE
Validate Server Key (#248) and docs (#368)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,9 @@ let OPTIONS (x : HttpRequest) = ``method`` "OPTIONS" x
 Server configuration
 --------------------
 
-The first argument to `startWebServer` is a configuration record with the following signature.
+The first argument to `startWebServer` is a configuration record with the
+following signature. (See [below](#changing-the-default-configuration) for tips
+on customizing this.)
 
 {% highlight fsharp %}
 /// The core configuration of suave. See also Suave.Web.defaultConfig which
@@ -190,3 +192,191 @@ error.
 type ErrorHandler = Exception -> String -> WebPart
 {% endhighlight %}
 
+### Changing the Default Configuration
+
+`defaultConfig` (defined in `Suave.Web`) has sane defaults, and for many users,
+these will be fine. However, since `SuaveConfig` is a record type, it is easy
+to swap out one or more of the default settings, tweaking the configuration to
+your precise needs. While we will discuss the default values below, you can
+review the defaults at the bottom of
+[Web.fs](https://github.com/SuaveIO/suave/blob/master/src/Suave/Web.fs).
+
+If you're looking to get started quickly, you can jump straight to sections
+detailing how to
+[change the IP addres or port](#changing-the-servers-ip-address-or-port),
+[specify a home directory](#changing-the-home-folder), and
+[set the server's cryptography key](#changing-the-servers-cryptography-key). For
+those whose descriptions are prefixed with "_(advanced)_", there is the
+potential to degrade Suave's performance; you should take great care when
+changing these from their default values.
+
+#### Changing the server's IP address or port
+
+The default binding for Suave is http://127.0.0.1:8080. It is rather simple to
+change that, though.
+
+{% highlight fsharp %}
+let myCfg =
+  { defaultConfig with
+      bindings = [ HttpBinding.createSimple HTTP "127.0.0.1" 8082 ]
+    }
+{% endhighlight %}
+
+As `bindings` is a list, you can also configure Suave to listen on any
+combination of IP addresses and ports.
+
+#### Changing the server's cryptography key
+
+Suave encrypts state stored in (sessions)[sessions.html], and the key used for
+that is the `serverKey` configuration setting. This key is required to be a
+specific length (256 bits as of this writing), so there is a `ServerKey` module
+that helps ensure that the key is the proper length.  The importance of this
+key, how to generate one, and how to plug it into your Suave config can be found
+under the [Server Keys](/sessions.html#server-keys) heading on that page.
+
+While the examples all demonstrate using a UTF-8 string, if you have 256 bits
+already in a byte array that you want to use as a server key, you can
+use `ServerKey.validate` instead of `ServerKey.create`; it will ensure that the
+key is the proper length.
+
+#### Changing the error handler
+
+Suave's default error handler logs the error, then returns an HTTP 500
+response. For local requests, it returns the error and stack trace in the body
+of the response; for others, it returns "Internal Server Error". The best way
+to customize it would be to start with `defaultErrorHandler`
+[near the top of Web.fs](https://github.com/SuaveIO/suave/blob/master/src/Suave/Web.fs),
+and tweak it to your liking. Then...
+
+{% highlight fsharp %}
+let myCfg =
+  { defaultConfig with
+      errorHandler = myErrorHandler
+    }
+{% endhighlight %}
+
+#### Changing the listen timeout
+
+_(advanced)_ This is the `TimeSpan` Suave will wait, on startup, for its request
+to bind to a specific TCP port to be successful. The default value is for
+`listenTimeout` is 2 seconds.
+
+#### Changing the cancellation token
+
+As with any asynchronous process, Suave can be controlled by the cancellation
+token used to start the process. By default, it uses the default cancellation
+token; however, giving `cancellationToken` a specific value here will allow for
+scenarios such as stopping and restarting Suave programmatically.
+
+#### Changing the buffer size
+
+_(advanced)_ The `bufferSize` that is used for socket operations (low-level
+communications). Its default value is 8192 bytes (8KB).
+
+#### Changing whether the buffer can automatically grow
+
+_(advanced)_ This boolean specifies whether the buffer manager is allowed to
+grow itself; `autoGrow` defaults to `true`.
+
+#### Changing the maximum concurrent operations
+
+_(advanced)_ This is the maximum number of concurrent socket operations that
+Suave will attempt to serve. The default value for `maxOps` is 100.
+
+#### Changing the MIME type map
+
+The `Writers` module has a default MIME type map, and that is the default map
+in the configuration.  Suave will not serve a file for which it cannot determine
+a MIME type, so if you are serving files that are not
+[current in the MIME type map](https://github.com/SuaveIO/suave/blob/master/src/Suave/Combinators.fs#L90),
+you will need to add this type.
+
+The above paragraph uses the word "map" several times, but it's technically a
+mapping function; to modify it, you need a function of your own.  As of this
+writing, .iso files are not in the default mapping.  Here's how we could add it.
+
+{% highlight fsharp %}
+let myMimeTypesMap ext =
+  match Writers.defaultMimeTypesMap ext with
+  | Some mime -> mime
+  | _ ->
+      match ext with
+      | ".iso" -> createMimeType "application/octet-stream" false
+      | _ -> None
+
+// and then
+
+let myCfg =
+  { defaultConfig with
+      mimeTypesMap = myMimeTypesMap
+    }
+{% endhighlight %}
+
+#### Changing the home folder
+
+Suave does not have a default home folder.  If you want to serve files from
+a folder, just specify it as a `Some` string.  If an absolute path is not given,
+it is interpreted from the current working directory when Suave was started.
+For example, if we follow the .NET Core convention of putting our
+publicly-available files under `wwwroot`, this example sets it as the home
+folder.
+
+{% highlight fsharp %}
+let myCfg =
+  { defaultConfig with
+      homeFolder = Some "./wwwroot"
+    }
+{% endhighlight %}
+
+#### Changing the compressed files folder
+
+Suave writes temporary files to disk when performing compression; the default
+directory where these files are placed is the current working directory when
+Suave was started.  However, if you want these files to go somewhere specific,
+you can specify them the exact same way we did above for the home folder; just
+set the `compressedFilesFolder` field instead.  (Suave deletes these files once
+they are served, so their lifetime is usually less than a second.)
+
+#### Changing logging options
+
+A good overview can be found [on the logging page](logs.html).
+
+#### Changing the default TCP server
+
+Suave's default TCP server uses the .NET CLR's socket implementation to bind
+and listen. Suave also comes with a TCP server implementation based on
+[LibUV](https://github.com/libuv/libuv); to use it...
+
+{% highlight fsharp %}
+open Suave.LibUv
+
+let myCfg =
+  { defaultConfig with
+      tcpServerFactory = new LibUvServerFactory()
+    }
+{% endhighlight %}
+
+#### Changing the default cookie serializer
+
+By default, Suave uses a binary formatter to serialize a `Map<string, obj>`
+into a string that is encrypted and used as a cookie payload. On the "State and
+Sessions" page, there is an
+[example of swapping out the default cookie serializer for one based on JSON.NET](/sessions.html#cookie-serializationbrof-particular-interest-to-net-core--netstandard20).
+
+#### Changing the default TLS provider
+
+_(advanced)_ The TLS provider supports encrypted communications (HTTPS). The
+default is an instance of the `DefaultTlsProvider` class; customizing it would
+require implementing the `TlsProvider` interface, and providing an instance of
+that class in your configuration's `tlsProvider` field.
+
+#### Changing whether the header is shown
+
+By default, Suave adds a `Server` header to each response, identifying itself
+as the software that handled the request. If this behavior is not desired, you
+can set `hideHeader` to `true`.
+
+#### Changing the maximum file upload size
+
+The `maxContentLength` field controls the maximum allowed upload size, in bytes;
+its default is 10000000 (10 MiB).

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,10 +234,10 @@ that helps ensure that the key is the proper length.  The importance of this
 key, how to generate one, and how to plug it into your Suave config can be found
 under the [Server Keys](/sessions.html#server-keys) heading on that page.
 
-While the examples all demonstrate using a UTF-8 string, if you have 256 bits
-already in a byte array that you want to use as a server key, you can
-use `ServerKey.validate` instead of `ServerKey.create`; it will ensure that the
-key is the proper length.
+While the examples all demonstrate using a base64-encoded string, if you have
+256 bits already in a byte array that you want to use as a server key, you can
+use `ServerKey.validate` instead of `ServerKey.fromBase64`; it will ensure that
+the key is the proper length.
 
 #### Changing the error handler
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,7 +227,7 @@ combination of IP addresses and ports.
 
 #### Changing the server's cryptography key
 
-Suave encrypts state stored in (sessions)[sessions.html], and the key used for
+Suave encrypts state stored in [sessions](sessions.html), and the key used for
 that is the `serverKey` configuration setting. This key is required to be a
 specific length (256 bits as of this writing), so there is a `ServerKey` module
 that helps ensure that the key is the proper length.  The importance of this

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -5,6 +5,12 @@ layout: default
 Getting Hold of Suave's Logs
 ----------------------------
 
+Current documentation for configuring Suave is either
+[in this sample](https://github.com/fable-compiler/fable-suave-scaffold/blob/master/src/Server/Server.fs#L24-L28)
+or [in the Logary readme](https://github.com/logary/logary#using-logary-in-a-library).
+
+The below details how to configure Suave v1.x with Logary v3.x:
+
 When you are using suave you will probably want to funnel all logs from the
 output to your own log sink. We provide the interface `Logger` to do that; just
 set the propery `logger` in the configuration to an instance of your thread-safe

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -74,7 +74,7 @@ Now, key in hand, we can continue our example from above. _(Note that hard-codin
 {% highlight fsharp %}
 let suaveCfg =
   { defaultConfig with
-      serverKey = Convert.FromBase64String [encoded-key]
+      serverKey = ServerKey.fromBase64 [encoded-key]
     }
 
 [<EntryPoint>]

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -64,7 +64,7 @@ open Suave.Utils
 open System
 
 let writeKey key = System.IO.File.WriteAllText ("key.txt", key)
-Crypto.generateKey Crypto.KeySize
+Crypto.generateKey Crypto.KeyLength
 |> Convert.ToBase64String
 |> writeKey
 {% endhighlight %}

--- a/src/Suave.Tests/ServerKey.fs
+++ b/src/Suave.Tests/ServerKey.fs
@@ -9,23 +9,23 @@ open Suave.Tests.TestUtilities
 [<Tests>]
 let serverKeyTest (cfg : SuaveConfig) =
   testList "server key" [
-    testList "create" [
+    testList "validate" [
       // No exception = successful test
       testCase "succeeds when the key has the correct number of bytes" <| fun _ ->
         let testKey : byte [] = Array.zeroCreate (int Crypto.KeyLength)
         ThreadSafeRandom.nextBytes testKey
-        let key = ServerKey.create testKey
+        let key = ServerKey.validate testKey
         Assert.Equal ("The two keys should be the same", testKey, key)
       testCase "fails when the key is too short" <| fun _ ->
         try
           int (Crypto.KeyLength - 1us)
-          |> (Array.zeroCreate >> ServerKey.create >> ignore)
+          |> (Array.zeroCreate >> ServerKey.validate >> ignore)
           failtest "A key smaller than the proper key length should have been invalid"
         with _ -> ()
       testCase "fails when the key is too long" <| fun _ ->
         try
           int (Crypto.KeyLength + 1us)
-          |> (Array.zeroCreate >> ServerKey.create >> ignore)
+          |> (Array.zeroCreate >> ServerKey.validate >> ignore)
           failtest "A key larger than the proper key length should have been invalid"
         with _ -> ()
       ]

--- a/src/Suave.Tests/ServerKey.fs
+++ b/src/Suave.Tests/ServerKey.fs
@@ -1,0 +1,62 @@
+module Suave.Tests.ServerKey
+
+open Expecto
+
+open Suave
+open Suave.Utils
+open Suave.Tests.TestUtilities
+
+[<Tests>]
+let serverKeyTest (cfg : SuaveConfig) =
+  testList "server key" [
+    testList "create" [
+      // No exception = successful test
+      testCase "succeeds when the key has the correct number of bytes" <| fun _ ->
+        let testKey : byte [] = Array.zeroCreate (int Crypto.KeyLength)
+        ThreadSafeRandom.nextBytes testKey
+        let key = ServerKey.create testKey
+        Assert.Equal ("The two keys should be the same", testKey, key)
+      testCase "fails when the key is too short" <| fun _ ->
+        try
+          int (Crypto.KeyLength - 1us)
+          |> (Array.zeroCreate >> ServerKey.create >> ignore)
+          failtest "A key smaller than the proper key length should have been invalid"
+        with _ -> ()
+      testCase "fails when the key is too long" <| fun _ ->
+        try
+          int (Crypto.KeyLength + 1us)
+          |> (Array.zeroCreate >> ServerKey.create >> ignore)
+          failtest "A key larger than the proper key length should have been invalid"
+        with _ -> ()
+      ]
+    testList "from base 64" [
+      testCase "succeeds when the string is well-formed" <| fun _ ->
+        let testKey : byte [] = Array.zeroCreate (int Crypto.KeyLength)
+        ThreadSafeRandom.nextBytes testKey
+        let key = ServerKey.fromBase64 (System.Convert.ToBase64String testKey)
+        Assert.Equal ("The two keys should be the same", testKey, key)
+      testCase "fails if key is wrong length" <| fun _ ->
+        let testKey : byte [] = Array.zeroCreate (int Crypto.KeyLength - 1)
+        ThreadSafeRandom.nextBytes testKey
+        try
+          ServerKey.fromBase64 (System.Convert.ToBase64String testKey) |> ignore
+          failtest "The server key creation should have failed"
+        with _ -> ()
+      testCase "fails if the key is malformed" <| fun _ ->
+        try
+          ServerKey.fromBase64 "this isn't a base64-encoded string" |> ignore
+          failtest "The base64 decoding should have failed"
+        with _ -> ()
+      ]
+    ]
+
+[<Tests>]
+let startUpTest (cfg : SuaveConfig) =
+  testList "startup validation" [
+    testCase "startup fails when key is wrong length" <| fun _ ->
+      try
+        let badKey : byte [] = Array.zeroCreate 5
+        startWebServerAsync { cfg with serverKey = badKey } (Successful.OK "") |> ignore
+        failtest "Server startup should have failed for a key the wrong length"
+      with _ -> ()
+    ]

--- a/src/Suave.Tests/Suave.Tests.fsproj
+++ b/src/Suave.Tests/Suave.Tests.fsproj
@@ -113,6 +113,7 @@
     <Compile Include="WebSocket.fs" />
     <Compile Include="Razor.fs" />
     <Compile Include="DotLiquid.fs" />
+    <Compile Include="ServerKey.fs" />
     <Compile Include="ExpectoExtensions.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -495,16 +495,13 @@ module Http =
   [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
   module ServerKey =
     
-    let create (key : byte []) : ServerKey =
+    let validate (key : ServerKey) =
       if key.Length <> int Crypto.KeyLength then
-        raise
-        <| ApplicationException
-            (sprintf "Invalid server key length - should be %i, but was %i"
-              Crypto.KeyLength key.Length)
+        failwithf "Invalid server key length - should be %i, but was %i" Crypto.KeyLength key.Length
       key
     
     let fromBase64 =
-      Convert.FromBase64String >> create
+      Convert.FromBase64String >> validate
     
   type IPAddress with
     static member tryParseC str =

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -491,7 +491,21 @@ module Http =
     static member writePreamble_ = Property<HttpResult,_> (fun x -> x.writePreamble) (fun v x -> { x with writePreamble = v })
 
   type ServerKey = byte []
-
+  
+  [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+  module ServerKey =
+    
+    let create (key : byte []) : ServerKey =
+      if key.Length <> int Crypto.KeyLength then
+        raise
+        <| ApplicationException
+            (sprintf "Invalid server key length - should be %i, but was %i"
+              Crypto.KeyLength key.Length)
+      key
+    
+    let fromBase64 =
+      Convert.FromBase64String >> create
+    
   type IPAddress with
     static member tryParseC str =
       match IPAddress.TryParse str with

--- a/src/Suave/Http.fsi
+++ b/src/Suave/Http.fsi
@@ -331,6 +331,16 @@ module Http =
   /// A server-key is a 256 bit key with high entropy
   type ServerKey = byte []
 
+  /// Utilities to ensure server keys are well-formed
+  [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+  module ServerKey =
+    
+    /// Ensure that a server key is the proper length
+    val create : byte [] -> ServerKey
+
+    /// Create a key from a base-64 encoded string
+    val fromBase64 : (string -> ServerKey)
+
   type IPAddress with
     /// Try parse the IP address from a string, returning a choice.
     static member tryParseC : ip:string -> Choice<IPAddress, unit>

--- a/src/Suave/Http.fsi
+++ b/src/Suave/Http.fsi
@@ -336,7 +336,7 @@ module Http =
   module ServerKey =
     
     /// Ensure that a server key is the proper length
-    val create : byte [] -> ServerKey
+    val validate : ServerKey -> ServerKey
 
     /// Create a key from a base-64 encoded string
     val fromBase64 : (string -> ServerKey)

--- a/src/Suave/Web.fs
+++ b/src/Suave/Web.fs
@@ -35,7 +35,7 @@ module Web =
   /// The return value from 'listening' (first item in tuple) gives you some metrics on
   /// how quickly suave started.
   let startWebServerAsync (config : SuaveConfig) (webpart : WebPart) =
-    ServerKey.create config.serverKey |> ignore
+    ServerKey.validate config.serverKey |> ignore
 
     let homeFolder, compressionFolder =
       ParsingAndControl.resolveDirectory config.homeFolder,

--- a/src/Suave/Web.fs
+++ b/src/Suave/Web.fs
@@ -35,6 +35,8 @@ module Web =
   /// The return value from 'listening' (first item in tuple) gives you some metrics on
   /// how quickly suave started.
   let startWebServerAsync (config : SuaveConfig) (webpart : WebPart) =
+    ServerKey.create config.serverKey |> ignore
+
     let homeFolder, compressionFolder =
       ParsingAndControl.resolveDirectory config.homeFolder,
       Path.Combine(ParsingAndControl.resolveDirectory config.compressedFilesFolder, "_temporary_compressed_files")


### PR DESCRIPTION
This creates a `ServerKey` module that will "create" (from a byte array) with validation, or create a key from a base64-encoded string.  On startup, the server runs the configured key through the `create` function to ensure it is well-formed.

This also documents every item in `SuaveConfig`, with examples for some commonly-modified parameters.  There is also verbiage for newer users, pointing them to the three most common "newbie" use cases (changing the port, choosing the home directory, setting a server key).