### PR TITLE
Make CORS 'exposeHeaders' to be list of strings

### DIFF
--- a/src/Suave.Tests/CORS.fs
+++ b/src/Suave.Tests/CORS.fs
@@ -158,5 +158,19 @@ let tests cfg =
           Expect.EmptyHeader("Should not have Access-Control-Allow-Credentials header", "Access-Control-Allow-Credentials", result)
 
         runWithConfig (composedApp (Some (cors corsConfig))) |> reqResp HttpMethod.GET "/cors" "" None None DecompressionMethods.None setHeaders asserts
+
+      testCase "Can respond with predefined Access-Control-Expose-Headers value" <| fun _ ->
+
+        let corsConfig = { defaultCORSConfig with exposeHeaders = InclusiveOption.Some ["Header1"; "Header2"] }
+
+        let setHeaders (request : HttpRequestMessage) =
+          request.Headers.Add("Origin", origin)
+          request
+
+        let asserts (result : HttpResponseMessage) =
+          let content = result.Content.ReadAsStringAsync().Result
+          eq "Access-Control-Expose-Headers header" "Header1, Header2" (result.Headers.GetValues("Access-Control-Expose-Headers") |> Seq.head)
+
+        runWithConfig (composedApp (Some (cors corsConfig))) |> reqResp HttpMethod.GET "/cors" "" None None DecompressionMethods.None setHeaders asserts
     ]
   ]

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -857,8 +857,8 @@ module CORS =
       /// Allow cookies? This is sent in the AccessControlAllowCredentials header.
       allowCookies            : bool
 
-      /// Should response headers be exposed to the client? This is sent in AccessControlExposeHeaders header.
-      exposeHeaders           : bool
+      /// The list of response headers exposed to client. This is sent in AccessControlExposeHeaders header.
+      exposeHeaders           : InclusiveOption<string list>
 
       /// Max age in seconds the user agent is allowed to cache the result of the request.
       maxAge                  : int option }
@@ -918,7 +918,15 @@ module CORS =
     Writers.setHeader AccessControlAllowOrigin value
 
   let private setExposeHeadersHeader config =
-    Writers.setHeader AccessControlExposeHeaders (config.exposeHeaders.ToString())
+    match config.exposeHeaders with
+    | InclusiveOption.None
+    | InclusiveOption.Some [] ->
+      succeed
+    | InclusiveOption.All ->
+      Writers.setHeader AccessControlExposeHeaders "*"
+    | InclusiveOption.Some hs ->
+      let header = hs |> String.concat(", ")
+      Writers.setHeader AccessControlExposeHeaders header
 
   let cors (config : CORSConfig) : WebPart =
     fun (ctx : HttpContext) ->
@@ -972,5 +980,5 @@ module CORS =
     { allowedUris           = InclusiveOption.All
       allowedMethods        = InclusiveOption.All
       allowCookies          = true
-      exposeHeaders         = true
+      exposeHeaders         = InclusiveOption.None
       maxAge                = None }

--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -1609,8 +1609,8 @@ module CORS =
       /// Allow cookies? This is sent in the AccessControlAllowCredentials header.
       allowCookies            : bool
 
-      /// Should response headers be exposed to the client? This is sent in AccessControlExposeHeaders header.
-      exposeHeaders           : bool
+      /// The list of response headers exposed to client. This is sent in AccessControlExposeHeaders header.
+      exposeHeaders           : InclusiveOption<string list>
 
       /// Max age in seconds the user agent is allowed to cache the result of the request.
       maxAge                  : int option }
@@ -1618,7 +1618,7 @@ module CORS =
     static member allowedUris_           : Property<CORSConfig, InclusiveOption<string list>>
     static member allowedMethods_        : Property<CORSConfig, InclusiveOption<HttpMethod list>>
     static member allowCookies_          : Property<CORSConfig, bool>
-    static member exposeHeaders_         : Property<CORSConfig, bool>
+    static member exposeHeaders_         : Property<CORSConfig, InclusiveOption<string list>>
     static member maxAge_                : Property<CORSConfig, int option>
 
 


### PR DESCRIPTION
Hello, please review this PR. 
It fixes #576 (CORS "Access-Control-Expose-Headers" header is invalid) by making ```exposeHeaders``` to be a predefined list of strings, instead of ```bool```.