### PR TITLE
fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
  - ps: Start-FileDownload 'https://github.com/libuv/libuv/archive/v1.9.1.zip'
  - cmd: 7z x v1.9.1.zip & cd libuv-1.9.1 & vcbuild.bat %arch% shared debug
  - cmd: mkdir src\Suave.Tests\bin\Release\ & cp libuv-1.9.1\Debug\libuv.dll src\Suave.Tests\bin\Release\libuv.dll
- - set PATH=C:\Ruby21\bin;%PATH% # use Ruby 2.1.9
+ - set PATH=C:\Ruby22\bin;%PATH% # use Ruby 2.2.6
  - cmd: ruby --version
  
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ install:
  - ps: Start-FileDownload 'https://github.com/libuv/libuv/archive/v1.9.1.zip'
  - cmd: 7z x v1.9.1.zip & cd libuv-1.9.1 & vcbuild.bat %arch% shared debug
  - cmd: mkdir src\Suave.Tests\bin\Release\ & cp libuv-1.9.1\Debug\libuv.dll src\Suave.Tests\bin\Release\libuv.dll
+ - set PATH=C:\Ruby21\bin;%PATH% # use Ruby 2.1.9
+ - cmd: ruby --version
  
 build_script:
  - cmd: gem sources -r https://rubygems.org/


### PR DESCRIPTION
@haf now appveyor is green, what was the issue with .net core sdk?

From the message in chat https://fsharp.slack.com/archives/C1KANN0BV/p1496826486641747 ):
> Hi guys, Suave's build of .Net Core has bitrotted again
Found .NET Core SDK 1.0.4 but require 1.0.1. Downloading and installing in ./tools/coreclr
bash --install-dir "/Users/h/dev/suave/suave/tools/coreclr" --channel "stable" --version "1.0.1
bash: --install-dir: invalid option
Usage:    bash [GNU long option] [option] ...
    bash [GNU long option] [option] script-file ...