### PR TITLE
resolve #626 - ignore Content-Length in some scenarios

### DIFF
--- a/src/Suave.Tests/HttpVerbs.fs
+++ b/src/Suave.Tests/HttpVerbs.fs
@@ -31,6 +31,12 @@ let gets cfg =
       Assert.Equal("empty string should always be returned by 204 No Content",
                    "", (runWithConfig NO_CONTENT |> req HttpMethod.GET "/" None))
 
+    testCase "204 No Content must not sends content-length header" <| fun _ ->
+      let headers = reqContentHeaders HttpMethod.GET "/" None (runWithConfig NO_CONTENT)
+      Assert.Equal("204 No Content must not sends content-length header",
+                   false,
+                   headers.Contains("Content-Length"))
+
     testCase "302 FOUND sends content-length header" <| fun _ ->
       let headers = reqContentHeaders HttpMethod.GET "/" None (runWithConfig (Redirection.FOUND "/url"))
       Assert.Equal("302 FOUND sends content-length header",

--- a/src/Suave/HttpOutput.fs
+++ b/src/Suave/HttpOutput.fs
@@ -20,6 +20,21 @@ module HttpOutput =
       { context with response = { context.response with headers = ("Connection","Keep-Alive") :: context.response.headers } }
     | _ -> context
 
+  let inline writeContentLengthHeader (content : byte[]) (context : HttpContext) = withConnection {
+    match context.request.``method``, context.response.status.code with
+    | (_, 100)
+    | (_, 101)
+    | (_, 204)
+    | (HttpMethod.CONNECT, 201)
+    | (HttpMethod.CONNECT, 202)
+    | (HttpMethod.CONNECT, 203)
+    | (HttpMethod.CONNECT, 205)
+    | (HttpMethod.CONNECT, 206) ->
+      do! asyncWriteLn ""
+    | _ ->
+      do! asyncWriteLn (String.Concat [| "Content-Length: "; content.Length.ToString(); Bytes.eol |])
+    }
+
   let inline writeHeaders exclusions (headers : (string*string) seq) = withConnection {
     for x,y in headers do
       if not (List.exists (fun y -> x.ToLower().Equals(y)) exclusions) then
@@ -46,7 +61,8 @@ module HttpOutput =
       | Some n ->
         let! (_, connection) = asyncWriteLn (String.Concat [| "Content-Encoding: "; n.ToString() |]) connection
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
-        let! (_, connection) = asyncWriteLn (String.Concat [| "Content-Length: "; content.Length.ToString(); Bytes.eol |]) connection
+        // https://tools.ietf.org/html/rfc7230#section-3.3.2
+        let! (_, connection) = writeContentLengthHeader content context connection
         if context.request.``method`` <> HttpMethod.HEAD && content.Length > 0 then
           let! (_,connection) = asyncWriteBufferedBytes content connection
           let! connection = flush connection
@@ -56,7 +72,8 @@ module HttpOutput =
           return connection
       | None ->
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
-        let! (_, connection) = asyncWriteLn (String.Concat [| "Content-Length: "; content.Length.ToString(); Bytes.eol |]) connection
+        // https://tools.ietf.org/html/rfc7230#section-3.3.2
+        let! (_, connection) = writeContentLengthHeader content context connection
         if context.request.``method`` <> HttpMethod.HEAD && content.Length > 0 then
           let! (_,connection) = asyncWriteBufferedBytes content connection
           let! connection = flush connection
@@ -70,7 +87,7 @@ module HttpOutput =
       }
     | NullContent -> socket {
         if writePreamble then
-          let! (_, connection) = asyncWriteLn (String.Concat [| "Content-Length: 0"; Bytes.eol |]) context.connection
+          let! (_, connection) = writeContentLengthHeader [||] context context.connection
           let! connection = flush connection
           return connection
         else


### PR DESCRIPTION
According to RFC7230, Content-Length must not be send in some scenarios. Tests related to WebSocket are missing as I can't find out how to access headers of handshake response in WebSocketSharp.