### PR TITLE
Fix netstandard1.6 DLL having 0.0.0.0 version

### DIFF
--- a/src/Suave/Suave.netcore.fsproj
+++ b/src/Suave/Suave.netcore.fsproj
@@ -74,6 +74,7 @@
     <Compile Include="WebSocket.fs" />
     <Compile Include="Owin.fs" />
     <Compile Include="Json.fs" />
+    <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />


### PR DESCRIPTION
This fixes #635 on my machine: the netstandard1.6 DLLs I build now have the correct version number (currently 2.1.1).

Note that in order to get this to build, I had to change the desired dotnet version in the Rakefile from 1.0.1 to 1.0.4: version 1.0.1 of the dotnet CLI tools is apparently no longer available to download from Microsoft's site. I've left that change out of this PR since it's unrelated, but if the build fails, changing `dotnet_version = '1.0.1'` to `dotnet_version = '1.0.4'` in the Rakefile may fix the build.