### PR TITLE
Update DotLiquid

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -66,13 +66,13 @@
 
   </Target>
 
-  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" >
+  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
     </PropertyGroup>
   </Target>
 
-  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" >
+  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
       <PaketReferencesFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references</PaketReferencesFilePath>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 RESTRICTION: == net46
 NUGET
   remote: https://www.nuget.org/api/v2
-    DotLiquid (2.0.158)
+    DotLiquid (2.0.174)
     FSharp.Core (3.1.2.5)
     Microsoft.AspNet.Razor (3.2.3)
     openssl.redist (1.0.1.25)
@@ -173,7 +173,7 @@ NUGET
       BenchmarkDotNet.Core (>= 0.10.1)
       Microsoft.CodeAnalysis.CSharp (>= 1.3.2)
       System.Threading.Tasks (>= 4.0)
-    DotLiquid (2.0.64)
+    DotLiquid (2.0.174)
     Expecto (4.0.3)
       Argu (>= 3.2)
       FSharp.Core (>= 3.1.2.5)

--- a/src/Suave.DotLiquid/Suave.DotLiquid.fsproj
+++ b/src/Suave.DotLiquid/Suave.DotLiquid.fsproj
@@ -85,7 +85,7 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="DotLiquid">
-          <HintPath>..\..\packages\DotLiquid\lib\net451\DotLiquid.dll</HintPath>
+          <HintPath>..\..\packages\DotLiquid\lib\net45\DotLiquid.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj
+++ b/src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj
@@ -17,6 +17,6 @@
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="DotLiquid" Version="2.0.55" />
+    <PackageReference Include="DotLiquid" Version="2.0.174" />
   </ItemGroup>
 </Project>

--- a/src/Suave.Tests/Suave.Tests.fsproj
+++ b/src/Suave.Tests/Suave.Tests.fsproj
@@ -246,7 +246,7 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="DotLiquid">
-          <HintPath>..\..\packages\tests\DotLiquid\lib\net451\DotLiquid.dll</HintPath>
+          <HintPath>..\..\packages\tests\DotLiquid\lib\net45\DotLiquid.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>


### PR DESCRIPTION
References #642. The `Paket.Restore.targets` file probably doesn't need to be updated.