### PR TITLE
Minor bug fix to error case in generateCookies()

### DIFF
--- a/src/Suave/Cookie.fs
+++ b/src/Suave/Cookie.fs
@@ -183,7 +183,7 @@ module Cookie =
                secure   = secure }
       |> slidingExpiry relativeExpiry
 
-    | err ->
+    | Choice2Of2 err ->
       failwithf "Suave internal error on encryption %A" err
 
   /// Tries to read the cookie by `cookieName` from the mapping of cookie-name


### PR DESCRIPTION
Missing Choice2Of2 in pattern match (very minor bug).