### PR TITLE
build "Suave.Testing" for netstandard 1.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -171,7 +171,7 @@ namespace :dotnetcli do
   desc 'Create Suave nugets packages'
   task :pack  => [:versioning, 'build/pkg-netcore', :coreclr_binaries] do
     out_dir = File.expand_path "build/pkg-netcore"
-    [ "src/Suave/Suave.netcore.fsproj", "src/Experimental/Suave.Experimental.netcore.fsproj", "src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj" ].each do |item|
+    [ "src/Suave/Suave.netcore.fsproj", "src/Suave.Testing/Suave.Testing.netcore.fsproj", "src/Experimental/Suave.Experimental.netcore.fsproj", "src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj" ].each do |item|
         system dotnet_exe_path, %W|pack #{item} --configuration #{Configuration} --output "#{out_dir}" --no-build -v n /p:Version=#{ENV['NUGET_VERSION']}|
     end
   end
@@ -182,7 +182,7 @@ namespace :dotnetcli do
   task :merge => :coreclr_binaries do
     system dotnet_exe_path, %W|restore tools/tools.proj -v n|
     Dir.chdir "tools" do
-      [ "Suave", "Suave.Experimental", "Suave.DotLiquid" ].each do |item|
+      [ "Suave", "Suave.Testing", "Suave.Experimental", "Suave.DotLiquid" ].each do |item|
           version = SemVer.find.format("%M.%m.%p%s")
           sourcenupkg = "../build/pkg/#{item}.#{version}.nupkg"
           netcorenupkg = "../build/pkg-netcore/#{item}.#{version}.nupkg"

--- a/src/Suave.Testing/Suave.Testing.netcore.fsproj
+++ b/src/Suave.Testing/Suave.Testing.netcore.fsproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <AssemblyName>Suave.Testing</AssemblyName>
+    <PackageId>Suave.Testing</PackageId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Testing.fs" />
+    <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Suave" Version="2.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="Expecto" Version="5.0.*" />
+  </ItemGroup>
+</Project>

--- a/src/Suave.netcore.sln
+++ b/src/Suave.netcore.sln
@@ -9,6 +9,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.DotLiquid.netcore", "
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Experimental.netcore", "Experimental\Suave.Experimental.netcore.fsproj", "{44C7A32F-EA26-49D4-82C9-8B51E17524D0}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Suave.Testing.netcore", "Suave.Testing\Suave.Testing.netcore.fsproj", "{D0F5B5CB-9CF6-4E32-8F46-030279294C32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,5 +60,17 @@ Global
 		{44C7A32F-EA26-49D4-82C9-8B51E17524D0}.Release|x64.Build.0 = Release|x64
 		{44C7A32F-EA26-49D4-82C9-8B51E17524D0}.Release|x86.ActiveCfg = Release|x86
 		{44C7A32F-EA26-49D4-82C9-8B51E17524D0}.Release|x86.Build.0 = Release|x86
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|x64.ActiveCfg = Debug|x64
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|x64.Build.0 = Debug|x64
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|x86.ActiveCfg = Debug|x86
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Debug|x86.Build.0 = Debug|x86
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x64.ActiveCfg = Release|x64
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x64.Build.0 = Release|x64
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x86.ActiveCfg = Release|x86
+		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hello - please review this PR.
It should fix https://github.com/SuaveIO/suave/issues/646.
We actually need NetStandard build of "Suave.Testing" to get rid of warnings, not increase Expecto version.

