### PR TITLE
Run tests under NetCore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: csharp
 dist: trusty
 sudo: required
 
-dotnet: 1.0.4
+dotnet: 2.0.0
 
 mono:
  - 4.8.0

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :dotnetcli do
   end
 
   task :coreclr_binaries => 'tools/coreclr' do
-    dotnet_version = '1.0.1'
+    dotnet_version = '2.0.0'
     dotnet_installed_version = get_installed_dotnet_version
     # check if required version of .net core sdk is already installed, otherwise download and install it
     if dotnet_installed_version == dotnet_version then
@@ -190,6 +190,14 @@ namespace :dotnetcli do
       end
     end
   end
+
+  task :unit_quick do
+    system dotnet_exe_path, %W|run --project src/Suave.Tests/Suave.Tests.netcore.fsproj -- --sequenced|
+  end
+
+  desc 'run unit tests on .NET Core 2.0'
+  task :unit => [:build_lib, :unit_quick]
+
 end
 
 namespace :tests do
@@ -234,7 +242,7 @@ desc 'create suave nuget with .NET Core'
 task :nugets_with_netcore => [:nugets, 'dotnetcli:do_netcorepackage', 'dotnetcli:merge']
 
 desc 'compile, gen versions and test'
-task :ci => [:compile, :'tests:unit']
+task :ci => [:compile, :'tests:unit', :'dotnetcli:unit']
 
 desc 'compile, gen versions, test'
 task :default => [:compile, :'tests:unit', :'docs:build']

--- a/Rakefile
+++ b/Rakefile
@@ -191,6 +191,13 @@ namespace :dotnetcli do
     end
   end
 
+  task :stress_quick do
+    system dotnet_exe_path, %W|run --project examples/Pong/Pong.netcore.fsproj|
+  end
+
+  desc 'run a stress test'
+  task :stress => [:build_lib, :stress_quick]
+
   task :unit_quick do
     system dotnet_exe_path, %W|run --project src/Suave.Tests/Suave.Tests.netcore.fsproj -- --sequenced|
   end

--- a/Rakefile
+++ b/Rakefile
@@ -171,22 +171,30 @@ namespace :dotnetcli do
   desc 'Create Suave nugets packages'
   task :pack  => [:versioning, 'build/pkg-netcore', :coreclr_binaries] do
     out_dir = File.expand_path "build/pkg-netcore"
-    [ "src/Suave/Suave.netcore.fsproj", "src/Suave.Testing/Suave.Testing.netcore.fsproj", "src/Experimental/Suave.Experimental.netcore.fsproj", "src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj" ].each do |item|
+    [ "src/Suave/Suave.netcore.fsproj", "src/Suave.Testing/Suave.Testing.netcore.fsproj", "src/Experimental/Suave.Experimental.netcore.fsproj", "src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj", "src/Suave.LibUv/Suave.LibUv.netcore.fsproj" ].each do |item|
         system dotnet_exe_path, %W|pack #{item} --configuration #{Configuration} --output "#{out_dir}" --no-build -v n /p:Version=#{ENV['NUGET_VERSION']}|
     end
   end
 
   task :do_netcorepackage => [ :restore, :build, :pack ]
 
+  def merge_nugets(dotnet_exe_path, item, version, framework)
+    sourcenupkg = "../build/pkg/#{item}.#{version}.nupkg"
+    netcorenupkg = "../build/pkg-netcore/#{item}.#{version}.nupkg"
+    system dotnet_exe_path, %W|mergenupkg --source "#{sourcenupkg}" --other "#{netcorenupkg}" --framework #{framework}|
+  end
+
   desc 'Merge standard and dotnetcli nupkgs; note the need to run :nugets before'
-  task :merge => :coreclr_binaries do
+  task :merge => :coreclr_binaries do    
     system dotnet_exe_path, %W|restore tools/tools.proj -v n|
+    version = SemVer.find.format("%M.%m.%p%s")
+
     Dir.chdir "tools" do
       [ "Suave", "Suave.Testing", "Suave.Experimental", "Suave.DotLiquid" ].each do |item|
-          version = SemVer.find.format("%M.%m.%p%s")
-          sourcenupkg = "../build/pkg/#{item}.#{version}.nupkg"
-          netcorenupkg = "../build/pkg-netcore/#{item}.#{version}.nupkg"
-          system dotnet_exe_path, %W|mergenupkg --source "#{sourcenupkg}" --other "#{netcorenupkg}" --framework netstandard1.6|
+          merge_nugets(dotnet_exe_path, item, version, "netstandard1.6")
+      end
+      [ "Suave.LibUv" ].each do |item|
+          merge_nugets(dotnet_exe_path, item, version, "netstandard2.0")
       end
     end
   end

--- a/examples/Example/NuGet.Config
+++ b/examples/Example/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!-- Locally built package -->
-    <add key="local-build" value="../../build/pkg" />
-  </packageSources>
-</configuration>

--- a/examples/Pong/Pong.netcore.fsproj
+++ b/examples/Pong/Pong.netcore.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AssemblyName>Example</AssemblyName>
+    <AssemblyName>Pong</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />

--- a/examples/Pong/Pong.netcore.fsproj
+++ b/examples/Pong/Pong.netcore.fsproj
@@ -3,14 +3,9 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>Example</AssemblyName>
-    <DefineConstants>$(DefineConstants);DNXCORE50</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\examples\haf\YoLo\YoLo.fs">
-      <Paket>True</Paket>
-      <Link>paket-files/YoLo.fs</Link>
-    </Compile>
-    <Compile Include="CounterDemo.fs" />
+    <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "projects": [ "src" ],
+  "projects": [ "src", "examples" ],
   "sdk": {
     "version": "2.0.0"
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "2.0.0"
   }
 }
 

--- a/src/Experimental/Suave.Experimental.netcore.fsproj
+++ b/src/Experimental/Suave.Experimental.netcore.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Suave.Experimental</AssemblyName>
@@ -15,11 +15,9 @@
     <Compile Include="Form.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Suave" Version="2.0.1" />
+    <ProjectReference Include="..\Suave\Suave.netcore.fsproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />

--- a/src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj
+++ b/src/Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Suave.DotLiquid</AssemblyName>
@@ -10,11 +10,9 @@
     <Compile Include="Library.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Suave" Version="2.0.1" />
+    <ProjectReference Include="..\Suave\Suave.netcore.fsproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="DotLiquid" Version="2.0.174" />

--- a/src/Suave.LibUv/Native.fs
+++ b/src/Suave.LibUv/Native.fs
@@ -64,81 +64,81 @@ type uv_handle_cb  = delegate of IntPtr -> unit
 [<UnmanagedFunctionPointer(CallingConvention.Cdecl)>]
 type uv_walk_cb  = delegate of IntPtr * IntPtr -> unit
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_tcp_init(IntPtr loop, IntPtr handle)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_tcp_nodelay(IntPtr handle, int enable)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_ip4_addr(string ip, int port, [<Out>] sockaddr_in& address)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_ip6_addr(string ip, int port, [<Out>] sockaddr_in6& address)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_tcp_bind(IntPtr handle, sockaddr_in& sockaddr, int flags)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl, EntryPoint = "uv_tcp_bind")>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl, EntryPoint = "uv_tcp_bind")>]
 extern int uv_tcp_bind6(IntPtr handle, sockaddr_in6&  sockaddr, uint32 flags)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_listen(IntPtr stream, int backlog, uv_connection_cb callback)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_accept(IntPtr server, IntPtr client)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_read_start(IntPtr stream, uv_alloc_cb alloc_callback, uv_read_cb read_callback)
 
-[<DllImport ("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport ("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_read_stop(IntPtr stream)
 
 /// Loops
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern IntPtr uv_default_loop()
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_loop_init(IntPtr handle)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_loop_close(IntPtr ptr)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_loop_size()
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern void uv_stop(IntPtr loop)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_run(IntPtr loop, int mode)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern void uv_update_time(IntPtr loop)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern uint64 uv_now(IntPtr loop)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern sbyte *uv_strerror(int systemErrorCode)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern sbyte *uv_err_name(int systemErrorCode)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern void uv_close(IntPtr handle, uv_close_cb cb)
 
-[<DllImport("libuv.dll", EntryPoint = "uv_write", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", EntryPoint = "uv_write", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_write(IntPtr req, IntPtr handle, uv_buf_t[] bufs, int bufcnt, uv_write_cb write_callback)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_idle_init(IntPtr loop, IntPtr idle)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_idle_start(IntPtr idle, uv_handle_cb callback)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_idle_stop(IntPtr idle)
 
 type uv_handle_type =
@@ -180,17 +180,17 @@ type uv_request_type =
 let UV_EOF = -4095
 let UV_ECONNRESET = -4077
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_handle_size(uv_handle_type t)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_req_size(uv_request_type t)
 
-[<DllImport("libuv.dll", CallingConvention=CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention=CallingConvention.Cdecl)>]
 extern int uv_async_init(IntPtr loop, IntPtr handle, uv_handle_cb callback)
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern int uv_async_send(IntPtr handle);
 
-[<DllImport("libuv.dll", CallingConvention = CallingConvention.Cdecl)>]
+[<DllImport("libuv", CallingConvention = CallingConvention.Cdecl)>]
 extern void uv_walk(IntPtr loop, uv_walk_cb cb, IntPtr arg);

--- a/src/Suave.LibUv/Suave.LibUv.netcore.fsproj
+++ b/src/Suave.LibUv/Suave.LibUv.netcore.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Suave.LibUv</AssemblyName>
+    <PackageId>Suave.LibUv</PackageId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Native.fs" />
+    <Compile Include="Tcp.fs" />
+    <Compile Include="LibUvServerFactory.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Suave\Suave.netcore.fsproj" PrivateAssets="All" />
+    <PackageReference Include="Libuv" Version="1.10.0" />
+  </ItemGroup>
+</Project>

--- a/src/Suave.Testing/Suave.Testing.netcore.fsproj
+++ b/src/Suave.Testing/Suave.Testing.netcore.fsproj
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Suave.Testing</AssemblyName>
@@ -11,11 +10,9 @@
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Suave" Version="2.0.1" />
+    <ProjectReference Include="..\Suave\Suave.netcore.fsproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="Expecto" Version="5.0.*" />
   </ItemGroup>
 </Project>

--- a/src/Suave.Tests/Auth.fs
+++ b/src/Suave.Tests/Auth.fs
@@ -174,6 +174,9 @@ let authTests cfg =
         use res''''' = interact HttpMethod.GET "/protected"
         Expect.equal (contentString res''''') "please authenticate" "should not have access to protected after logout"
 
+    #if NETCOREAPP2_0
+    ptestCase "test session is maintained across requests" <| fun _ -> ()
+    #else
     testCase "test session is maintained across requests" <| fun _ ->
       // given
       let ctx =
@@ -200,7 +203,11 @@ let authTests cfg =
 
         use res'' = interact HttpMethod.GET "/"
         Expect.equal (contentString res'') "2" "should return number two")
+    #endif
 
+    #if NETCOREAPP2_0
+    ptestCase "set more than one variable in the session" <| fun _ -> ()
+    #else
     testCase "set more than one variable in the session" <| fun _ ->
       // given
       let ctx =
@@ -228,7 +235,11 @@ let authTests cfg =
 
         use res''' = interact HttpMethod.GET "/get_b"
         Expect.equal (contentString res''') "b" "should return b")
+    #endif
 
+    #if NETCOREAPP2_0
+    ptestCase "set two session values on the same request" <| fun _ -> ()
+    #else
     testCase "set two session values on the same request" <| fun _ ->
       // given
       let ctx =
@@ -251,4 +262,5 @@ let authTests cfg =
 
         use res'' = interact HttpMethod.GET "/get_a"
         Expect.equal (contentString res'') "a" "should return a")
+    #endif
     ]

--- a/src/Suave.Tests/HttpEmbedded.fs
+++ b/src/Suave.Tests/HttpEmbedded.fs
@@ -12,11 +12,7 @@ let embedded_resources cfg =
   let runWithConfig = runWith cfg
 
   testList "test Embedded.browse" [
-      #if NETCOREAPP2_0
-      ptestCase "200 OK returns embedded file" <| fun _ -> ()
-      #else
       testCase "200 OK returns embedded file" <| fun _ ->
         let actual = runWithConfig browseDefaultAsssembly |> req HttpMethod.GET "/embedded-resource.txt" None
         Expect.equal actual "Hello World!" "expecting 'Hello World!'"
-      #endif
     ]

--- a/src/Suave.Tests/HttpEmbedded.fs
+++ b/src/Suave.Tests/HttpEmbedded.fs
@@ -12,7 +12,11 @@ let embedded_resources cfg =
   let runWithConfig = runWith cfg
 
   testList "test Embedded.browse" [
+      #if NETCOREAPP2_0
+      ptestCase "200 OK returns embedded file" <| fun _ -> ()
+      #else
       testCase "200 OK returns embedded file" <| fun _ ->
         let actual = runWithConfig browseDefaultAsssembly |> req HttpMethod.GET "/embedded-resource.txt" None
         Expect.equal actual "Hello World!" "expecting 'Hello World!'"
+      #endif
     ]

--- a/src/Suave.Tests/Parsing.fs
+++ b/src/Suave.Tests/Parsing.fs
@@ -60,23 +60,23 @@ let parsingMultipart cfg =
       let actual = runWithConfig testMultipartForm |> req HttpMethod.POST "/" (Some byteArrayContent)
       Expect.equal actual "Bob <bob@wishfulcoding.mailgun.org>" "Should return correct value"
 
-    testCase "parsing a large urlencoded form data" <| fun _ ->
+    testCase "parsing a large urlencoded form data - stripped-text" <| fun _ ->
       Assert.Equal("", "hallo wereld",
         runWithConfig (testUrlEncodedForm "stripped-text") |> reqGZip HttpMethod.POST "/" (Some <| new StringContent(postData2, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
-    testCase "parsing a large urlencoded form data" <| fun _ ->
+    testCase "parsing a large urlencoded form data - from" <| fun _ ->
       Assert.Equal("", "Pepijn de Vos <pepijndevos@gmail.com>",
         runWithConfig (testUrlEncodedForm "from") |> reqGZip HttpMethod.POST "/" (Some <| new StringContent(postData3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
-    testCase "parsing a large urlencoded form data" <| fun _ ->
+    testCase "parsing a large urlencoded form data - subject" <| fun _ ->
       Assert.Equal("", "no attachment 2",
         runWithConfig (testUrlEncodedForm "subject") |> reqGZip HttpMethod.POST "/" (Some <| new StringContent(postData3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
-    testCase "parsing a large urlencoded form data" <| fun _ ->
+    testCase "parsing a large urlencoded form data - body-plain" <| fun _ ->
       Assert.Equal("", "identifier 123abc",
         runWithConfig (testUrlEncodedForm "body-plain") |> reqGZip HttpMethod.POST "/" (Some <| new StringContent(postData3, Encoding.UTF8, "application/x-www-form-urlencoded")))
 
-    testCase "parsing a large urlencoded form data" <| fun _ ->
+    testCase "parsing a large urlencoded form data - body-html" <| fun _ ->
       Assert.Equal("", "field-does-not-exists",
         runWithConfig (testUrlEncodedForm "body-html") |> reqGZip HttpMethod.POST "/" (Some <| new StringContent(postData3, Encoding.UTF8, "application/x-www-form-urlencoded")))
   ]

--- a/src/Suave.Tests/Program.fs
+++ b/src/Suave.Tests/Program.fs
@@ -8,6 +8,10 @@ open ExpectoExtensions
 
 open System
 
+#if NETCOREAPP2_0
+open System.Runtime.InteropServices
+#endif
+
 [<EntryPoint>]
 let main args =
 
@@ -23,9 +27,20 @@ let main args =
         bindings = [ HttpBinding.createSimple HTTP "127.0.0.1" 9001 ]
         logger   = Targets.create Warn [| "Suave"; "Tests" |] }
 
-  Console.WriteLine "Running tests with default TCP engine."
-  let firstRun = defaultMainThisAssemblyWithParam testConfig args
-  Console.WriteLine "Done."
+  let mutable firstRun = 0
+  let runDefaultEngine() =
+    Console.WriteLine "Running tests with default TCP engine."
+    firstRun <- defaultMainThisAssemblyWithParam testConfig args
+    Console.WriteLine "Done."
+
+  #if NETCOREAPP2_0
+  if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
+    Console.WriteLine "Skipping default TCP engine tests for non Windows platforms."
+  else
+    runDefaultEngine()
+  #else
+  runDefaultEngine()
+  #endif
 
   if firstRun <> 0 then
     firstRun

--- a/src/Suave.Tests/Suave.Tests.netcore.fsproj
+++ b/src/Suave.Tests/Suave.Tests.netcore.fsproj
@@ -23,7 +23,10 @@
     <Compile Include="Web.fs" />
     <Compile Include="HttpWriters.fs" />
     <Compile Include="HttpFile.fs" />
-    <Compile Include="HttpEmbedded.fs" /> 
+
+    <!-- No browseDefaultAsssembly for netstandard 1.6 -->
+    <!-- Compile Include="HttpEmbedded.fs" /--> 
+
     <Compile Include="HttpVerbs.fs" />
     <Compile Include="HttpApplicatives.fs" />
     <Compile Include="HttpAuthentication.fs" />

--- a/src/Suave.Tests/Suave.Tests.netcore.fsproj
+++ b/src/Suave.Tests/Suave.Tests.netcore.fsproj
@@ -1,0 +1,114 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>Suave.Tests</AssemblyName>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="large_xml.xml" />
+    <Content Include="PerfLab.fsx" />
+    <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
+    <Compile Include="TestUtilities.fs" />
+    <Content Include="regressions\Bug105-StopsResponding.fsx" />
+    <Compile Include="regressions\Bug256-FormDataParsing.fs" />
+    <Content Include="regressions\Bug435.fsx" />
+    <Compile Include="regressions\Bug435-OwinContentLength.fs" />
+    <Content Include="regressions\pix.gif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="Smoke.fs" />
+    <Compile Include="Utils.fs" />
+    <Compile Include="Pools.fs" />
+    <Compile Include="AsyncSocket.fs" />
+    <Compile Include="Web.fs" />
+    <Compile Include="HttpWriters.fs" />
+    <Compile Include="HttpFile.fs" />
+    <Compile Include="HttpEmbedded.fs" /> 
+    <Compile Include="HttpVerbs.fs" />
+    <Compile Include="HttpApplicatives.fs" />
+    <Compile Include="HttpAuthentication.fs" />
+    <Compile Include="CORS.fs" />
+    <Compile Include="HttpRequestHeaders.fs" />
+    <Compile Include="Parsing.fs" />
+    <Compile Include="Model.fs" />
+    <Compile Include="Connection.fs" />
+    <Compile Include="Sscanf.fs" />
+    <Compile Include="Json.fs" />
+    <Compile Include="Owin.fs" />
+    <Compile Include="Auth.fs" />
+    <Compile Include="LogLevel.fs" />
+    <Compile Include="TraceHeader.fs" />
+    <Compile Include="Logger.fs" />
+    <Compile Include="Cookie.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="WebSocket.fs" />
+
+    <!-- No RazorEngine for netcore -->
+    <!-- Compile Include="Razor.fs" /-->
+
+    <Compile Include="DotLiquid.fs" />
+    <Compile Include="ServerKey.fs" />
+    <Compile Include="ExpectoExtensions.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="paket.references" />
+    <None Include="suave.p12">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="test-text-file.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <EmbeddedResource Include="embedded-resource.txt" />
+    <Content Include="request.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="request-1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="request-2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="request-multipartmixed-twofiles.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="request-binary-n-formdata.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Include="request-no-host-header.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="request-hangs.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="App.config" />
+    <Content Include="Views\razor.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Views\razor-de-DE.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fallback.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="liquid\hello.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="liquid\parent.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="liquid\child.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Suave\Suave.netcore.fsproj" />
+    <ProjectReference Include="..\Suave.LibUv\Suave.LibUv.netcore.fsproj" />
+    <ProjectReference Include="..\Suave.Testing\Suave.Testing.netcore.fsproj" />
+    <ProjectReference Include="..\Suave.DotLiquid\Suave.DotLiquid.netcore.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Expecto" Version="5.1.1" />
+    <PackageReference Include="Expecto.FsCheck" Version="5.1.1" />
+    <PackageReference Include="websocketsharp.core" Version="1.0.0" />
+    <PackageReference Include="Http.fs" Version="4.1.2" />
+  </ItemGroup>
+</Project>

--- a/src/Suave.Tests/WebSocket.fs
+++ b/src/Suave.Tests/WebSocket.fs
@@ -242,7 +242,10 @@ let websocketTests cfg =
         mre.WaitOne() |> ignore
         clientWebSocket.Close()
         Expect.isTrue (testByteArray (int PayloadSize.Bit32) echo.Value) "Should be echoed"
-
+      
+      #if NETCOREAPP2_0
+      ptestCase "echo large number of messages to client" <| fun _ -> ()
+      #else      
       testCase websocketUrl subprotocols "echo large number of messages to client" <| fun mre clientWebSocket ->
         let amountOfMessages = 1000
         let echo = ref []
@@ -265,6 +268,7 @@ let websocketTests cfg =
 
         Expect.equal echo.Value expectedMessages "should be equal"
         Expect.equal (!count) amountOfMessages "received message count on websocket"
+      #endif
     ]
   
   testList "websocket tests" [ websocketTests websocketAppUrl [||]

--- a/src/Suave.Tests/WebSocket.fs
+++ b/src/Suave.Tests/WebSocket.fs
@@ -242,10 +242,7 @@ let websocketTests cfg =
         mre.WaitOne() |> ignore
         clientWebSocket.Close()
         Expect.isTrue (testByteArray (int PayloadSize.Bit32) echo.Value) "Should be echoed"
-      
-      #if NETCOREAPP2_0
-      ptestCase "echo large number of messages to client" <| fun _ -> ()
-      #else      
+
       testCase websocketUrl subprotocols "echo large number of messages to client" <| fun mre clientWebSocket ->
         let amountOfMessages = 1000
         let echo = ref []
@@ -268,7 +265,6 @@ let websocketTests cfg =
 
         Expect.equal echo.Value expectedMessages "should be equal"
         Expect.equal (!count) amountOfMessages "received message count on websocket"
-      #endif
     ]
   
   testList "websocket tests" [ websocketTests websocketAppUrl [||]

--- a/src/Suave.netcore.sln
+++ b/src/Suave.netcore.sln
@@ -13,6 +13,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Suave.Testing.netcore", "Su
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Tests.netcore", "Suave.Tests\Suave.Tests.netcore.fsproj", "{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Example.netcore", "..\examples\Example\Example.netcore.fsproj", "{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Pong.netcore", "..\examples\Pong\Pong.netcore.fsproj", "{A66900CD-B912-4C6C-B76A-008E94802380}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,5 +90,29 @@ Global
 		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x64.Build.0 = Release|x64
 		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x86.ActiveCfg = Release|x86
 		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x86.Build.0 = Release|x86
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|x64.ActiveCfg = Debug|x64
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|x64.Build.0 = Debug|x64
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|x86.ActiveCfg = Debug|x86
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Debug|x86.Build.0 = Debug|x86
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|x64.ActiveCfg = Release|x64
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|x64.Build.0 = Release|x64
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|x86.ActiveCfg = Release|x86
+		{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}.Release|x86.Build.0 = Release|x86
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|x64.ActiveCfg = Debug|x64
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|x64.Build.0 = Debug|x64
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|x86.ActiveCfg = Debug|x86
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Debug|x86.Build.0 = Debug|x86
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|x64.ActiveCfg = Release|x64
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|x64.Build.0 = Release|x64
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|x86.ActiveCfg = Release|x86
+		{A66900CD-B912-4C6C-B76A-008E94802380}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 EndGlobal

--- a/src/Suave.netcore.sln
+++ b/src/Suave.netcore.sln
@@ -11,6 +11,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Experimental.netcore"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Suave.Testing.netcore", "Suave.Testing\Suave.Testing.netcore.fsproj", "{D0F5B5CB-9CF6-4E32-8F46-030279294C32}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Tests.netcore", "Suave.Tests\Suave.Tests.netcore.fsproj", "{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,5 +74,17 @@ Global
 		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x64.Build.0 = Release|x64
 		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x86.ActiveCfg = Release|x86
 		{D0F5B5CB-9CF6-4E32-8F46-030279294C32}.Release|x86.Build.0 = Release|x86
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|x64.ActiveCfg = Debug|x64
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|x64.Build.0 = Debug|x64
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|x86.ActiveCfg = Debug|x86
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Debug|x86.Build.0 = Debug|x86
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x64.ActiveCfg = Release|x64
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x64.Build.0 = Release|x64
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x86.ActiveCfg = Release|x86
+		{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 EndGlobal

--- a/src/Suave.netcore.sln
+++ b/src/Suave.netcore.sln
@@ -3,19 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.netcore", "Suave\Suave.netcore.fsproj", "{87A7BC50-A26D-4370-B175-BF4BB4E7416B}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.netcore", "Suave/Suave.netcore.fsproj", "{87A7BC50-A26D-4370-B175-BF4BB4E7416B}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.DotLiquid.netcore", "Suave.DotLiquid\Suave.DotLiquid.netcore.fsproj", "{FF35C4E4-9B3C-42F1-96C3-6972D9A94DAD}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.DotLiquid.netcore", "Suave.DotLiquid/Suave.DotLiquid.netcore.fsproj", "{FF35C4E4-9B3C-42F1-96C3-6972D9A94DAD}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Experimental.netcore", "Experimental\Suave.Experimental.netcore.fsproj", "{44C7A32F-EA26-49D4-82C9-8B51E17524D0}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Experimental.netcore", "Experimental/Suave.Experimental.netcore.fsproj", "{44C7A32F-EA26-49D4-82C9-8B51E17524D0}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Suave.Testing.netcore", "Suave.Testing\Suave.Testing.netcore.fsproj", "{D0F5B5CB-9CF6-4E32-8F46-030279294C32}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Suave.Testing.netcore", "Suave.Testing/Suave.Testing.netcore.fsproj", "{D0F5B5CB-9CF6-4E32-8F46-030279294C32}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Tests.netcore", "Suave.Tests\Suave.Tests.netcore.fsproj", "{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Suave.Tests.netcore", "Suave.Tests/Suave.Tests.netcore.fsproj", "{571C4BDE-692A-4AED-BE44-7F1F7A25EBED}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Example.netcore", "..\examples\Example\Example.netcore.fsproj", "{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Example.netcore", "../examples/Example/Example.netcore.fsproj", "{22083A27-CB0B-48CA-A9E9-9DD3A4DCF841}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Pong.netcore", "..\examples\Pong\Pong.netcore.fsproj", "{A66900CD-B912-4C6C-B76A-008E94802380}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Pong.netcore", "../examples/Pong/Pong.netcore.fsproj", "{A66900CD-B912-4C6C-B76A-008E94802380}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Suave/Suave.netcore.fsproj
+++ b/src/Suave/Suave.netcore.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Suave</AssemblyName>
@@ -15,7 +15,6 @@
       <Paket>True</Paket>
       <Link>Utils/Facade.fs</Link>
     </Compile>
-    <Compile Include="../../paket-files/haf/YoLo/YoLo.fs" />
     <Compile Include="Utils/Aether.fs" />
     <Compile Include="Utils/AsyncExtensions.fs" />
     <Compile Include="Utils/AsyncResultCell.fs" />
@@ -32,7 +31,6 @@
     <Compile Include="Utils/Property.fs" />
     <Compile Include="Utils/Parse.fs" />
     <Compile Include="Utils/CultureInfoCache.fs" />
-    <Compile Include="../../paket-files/logary/logary/src/Logary.Facade/Facade.fs" />
     <Compile Include="Utils/TraceHeader.fs" />
     <Compile Include="Globals.fs" />
     <Compile Include="CookieSerialiser.fs" />
@@ -77,8 +75,6 @@
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="System.Data.Common" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />

--- a/tools/tools.proj
+++ b/tools/tools.proj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="1.*" />
+    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="2.1.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Summary:
- upgraded all ```*.netcore.fsproj``` to 2.0 SDK
- ported ```Suave.LibUv``` to ```netstandard 2.0```,  becase some APIs are missing in ```netstandard 1.6``` (like ```BeginThreadAffinity``` and others)
- run Suave tests under ```netcoreapp 2.0``` (no ```WebSocketSharp``` and  ```Suave.LibUv``` for ```netstandard 1.6```)
- include NetCore tests to CI pipeline
- remove dependency on specific version of Suave for other NetCore NuGet packages

Notes:
- ```Http.fs``` - need to wait for NetCore release. Now using full-framework package.  //cc @seanamos and @ivpadim
- Linux tests are running only with "LibUv TCP engine".  
Reason: some tests (which start and stop server) are failing with "Default TCP engine" - it is not possible on Linux to dispose socket and re-bind - https://github.com/dotnet/corefx/issues/24562. 

We can do something similar as for Kestrel: https://github.com/aspnet/KestrelHttpServer/pull/2111, but this requires building Suave for ```netstandard 2.0```, since there are no ```Handle``` property for ```Socket``` under 1.6.

- Three ```Auth.fs``` tests are excluded because Suave cookie serialization code fails to serialize ```FSharpMap```. Probably that code should not use ```DataContractJsonSerializer``` and use Newtonsoft instead? 

- After converting to 2.0 SDK - there are a lot of build warnings like 
```
Encountered conflict between 'Runtime:..\.nuget\packages\microsoft.win32.registry\4.0.0\runtimes\unix\lib\netstan
dard1.3\Microsoft.Win32.Registry.dll' and 'Runtime:..\olbog\.nuget\packages\microsoft.win32.registry\4.0.0\runtimes\win\lib\nets
tandard1.3\Microsoft.Win32.Registry.dll'.  Could not determine winner due to equal file and assembly versions.
```
but according to this https://github.com/dotnet/standard/issues/505 we may skip those warnings