### PR TITLE
Use latest "FSharp.Core" for NetCore unit tests

### DIFF
--- a/src/Suave.Tests/Auth.fs
+++ b/src/Suave.Tests/Auth.fs
@@ -174,9 +174,6 @@ let authTests cfg =
         use res''''' = interact HttpMethod.GET "/protected"
         Expect.equal (contentString res''''') "please authenticate" "should not have access to protected after logout"
 
-    #if NETCOREAPP2_0
-    ptestCase "test session is maintained across requests" <| fun _ -> ()
-    #else
     testCase "test session is maintained across requests" <| fun _ ->
       // given
       let ctx =
@@ -203,11 +200,7 @@ let authTests cfg =
 
         use res'' = interact HttpMethod.GET "/"
         Expect.equal (contentString res'') "2" "should return number two")
-    #endif
 
-    #if NETCOREAPP2_0
-    ptestCase "set more than one variable in the session" <| fun _ -> ()
-    #else
     testCase "set more than one variable in the session" <| fun _ ->
       // given
       let ctx =
@@ -235,11 +228,7 @@ let authTests cfg =
 
         use res''' = interact HttpMethod.GET "/get_b"
         Expect.equal (contentString res''') "b" "should return b")
-    #endif
 
-    #if NETCOREAPP2_0
-    ptestCase "set two session values on the same request" <| fun _ -> ()
-    #else
     testCase "set two session values on the same request" <| fun _ ->
       // given
       let ctx =
@@ -262,5 +251,4 @@ let authTests cfg =
 
         use res'' = interact HttpMethod.GET "/get_a"
         Expect.equal (contentString res'') "a" "should return a")
-    #endif
     ]

--- a/src/Suave.Tests/Suave.Tests.netcore.fsproj
+++ b/src/Suave.Tests/Suave.Tests.netcore.fsproj
@@ -107,7 +107,7 @@
     <ProjectReference Include="..\Suave.DotLiquid\Suave.DotLiquid.netcore.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.18" />
+    <PackageReference Include="FSharp.Core" Version="4.3.2" />
     <PackageReference Include="Expecto" Version="5.1.1" />
     <PackageReference Include="Expecto.FsCheck" Version="5.1.1" />
     <PackageReference Include="websocketsharp.core" Version="1.0.0" />


### PR DESCRIPTION
Using latest "FSharp.Core" (with Netstandard 2.0 support) will allow to binary serialize ```FSharpMap```, which allows to serialize cookies using Suave ```BinaryFormatterSerialiser```.

Previously NetStandard ```FSharpMap``` was not binary serializable -  this caused 3 tests to fail.

This is for tests-project only. 
All Suave NetCore packages are still depending on "4.1.18".