### PR TITLE
More correct rebinding to same address for NetCore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 ---
 language: csharp
 
+os:
+  - linux
+  - osx
+
 dist: trusty
-sudo: required
 
 dotnet: 2.0.3
 
@@ -15,13 +18,16 @@ mono:
 install:
  - rvm install 2.2.3
  - gem install bundler
- - sudo apt-get update -y
- - sudo apt-get install -y gnupg automake libtool
- - curl -sSL https://github.com/libuv/libuv/archive/v1.9.1.tar.gz | tar zxf - -C /tmp
- - (cd /tmp/libuv-1.9.1/ && ./autogen.sh && ./configure && make && sudo make install)
- - sudo ldconfig
- # for apache bench (ab)
- - sudo apt-get install -qq apache2-utils
+ - if [ "$TRAVIS_OS_NAME" == "linux" ];
+   then sudo apt-get update -y;
+   else brew update;
+   fi
+
+before_script:
+ - if [ "$TRAVIS_OS_NAME" == "linux" ];
+   then export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/.nuget/packages/libuv/1.10.0/runtimes/linux-x64/native;
+   else ln -s ~/.nuget/packages/libuv/1.10.0/runtimes/osx/native/libuv.dylib /usr/local/lib/libuv.dylib;
+   fi
 
 script:
  - bundle && bundle exec rake ci
@@ -30,4 +36,3 @@ matrix:
   allow_failures:
     - mono: latest
     - mono: weekly
-    - mono: 5.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -59,20 +59,8 @@ asmver_files :asmver => :versioning do |a|
   end
 end
 
-task :libs do
-  unless Albacore.windows?
-    system "pkg-config --cflags libuv" do |ok, res|
-      if !ok
-        raise %{
-  You seem to be missing `libuv`, which needs to be installed. See https://github.com/SuaveIO/suave#libuv-installation
-  }
-      end
-    end
-  end
-end
-
 desc 'Perform full build'
-task :compile => [:libs, :versioning, :restore, :asmver, :compile_quick]
+task :compile => [:versioning, :restore, :asmver, :compile_quick]
 
 desc 'clean the project'
 build :clean do |b|

--- a/src/Suave/App.config
+++ b/src/Suave/App.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <dllmap os="osx" dll="libuv.dll" target="libuv.dylib"/>
-  <dllmap os="!windows,osx" dll="libuv.dll" target="libuv.so"/>
-</configuration>

--- a/src/Suave/Native.fs
+++ b/src/Suave/Native.fs
@@ -1,0 +1,12 @@
+module internal Suave.Native
+
+open System
+open System.Runtime.InteropServices
+
+let SOL_SOCKET_OSX = 0xffff
+let SO_REUSEADDR_OSX = 0x0004
+let SOL_SOCKET_LINUX = 0x0001
+let SO_REUSEADDR_LINUX = 0x0002
+
+[<DllImport("libc", SetLastError = true)>]
+extern int setsockopt(IntPtr socket, int level, int option_name, IntPtr option_value, uint32 option_len)

--- a/src/Suave/Suave.fsproj
+++ b/src/Suave/Suave.fsproj
@@ -146,7 +146,6 @@
     <Compile Include="Json.fs" />
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
     <None Include="paket.references" />
-    <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/Suave/Suave.netcore.fsproj
+++ b/src/Suave/Suave.netcore.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="Sockets/SocketMonad.fs" />
     <Compile Include="Sockets/AsyncSocket.fs" />
     <Compile Include="Sockets/TransportStream.fs" />
+    <Compile Include="Native.fs" />
     <Compile Include="Tcp.fs" />
     <Compile Include="TcpServerFactory.fs" />
     <Compile Include="Sscanf.fs" />


### PR DESCRIPTION
This PR is doing same thing for Suave as PR https://github.com/aspnet/KestrelHttpServer/pull/2111
for ```Kestrel.Transport.Sockets```, because following Suave code in ```Tcp.fs``` is not fully correct:
```fsharp
#if NETSTANDARD2_0
listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1)		
#endif
```
see also following discussion: https://github.com/dotnet/corefx/issues/24562.

Also two additional things added:
- Add MacOS to CI
- do not build ```libuv``` for Travis - use it from NuGet folder - same as for AppVeyor.

What do you think about this?