### PR TITLE
Use latest Http.fs for NetCore tests

### DIFF
--- a/src/Suave.Tests/Suave.Tests.netcore.fsproj
+++ b/src/Suave.Tests/Suave.Tests.netcore.fsproj
@@ -111,6 +111,6 @@
     <PackageReference Include="Expecto" Version="5.1.1" />
     <PackageReference Include="Expecto.FsCheck" Version="5.1.1" />
     <PackageReference Include="websocketsharp.core" Version="1.0.0" />
-    <PackageReference Include="Http.fs" Version="4.1.2" />
+    <PackageReference Include="Http.fs" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Suave.Tests/regressions/Bug256-FormDataParsing.fs
+++ b/src/Suave.Tests/regressions/Bug256-FormDataParsing.fs
@@ -41,7 +41,7 @@ let tests (cfg : SuaveConfig) =
   let uriFor (res : string) =
     SuaveConfig.firstBindingUri cfg res ""
 
-  let postTo res = Request.create Post (uriFor res) |> Request.keepAlive false
+  let postTo res = Request.create Post (uriFor res) |> Request.setHeader (Connection "Close")
 
   testCase "can send/receive" <| fun _ ->
     let ctx = runWithConfig app
@@ -49,7 +49,6 @@ let tests (cfg : SuaveConfig) =
       use fs = File.OpenRead (pathOf "regressions/pix.gif")
       let file = "pix.gif", ContentType.create("image", "gif"), StreamData fs
 
-      //printfn "--- get response"
       let data =
         postTo "gifs/echo"
         |> Request.body (BodyForm [ FormFile ("img", file) ])

--- a/src/Suave.Tests/regressions/Bug256-FormDataParsing.fs
+++ b/src/Suave.Tests/regressions/Bug256-FormDataParsing.fs
@@ -41,7 +41,7 @@ let tests (cfg : SuaveConfig) =
   let uriFor (res : string) =
     SuaveConfig.firstBindingUri cfg res ""
 
-  let postTo res = Request.create Post (uriFor res) |> Request.setHeader (Connection "Close")
+  let postTo res = Request.create Post (uriFor res)
 
   testCase "can send/receive" <| fun _ ->
     let ctx = runWithConfig app


### PR DESCRIPTION
This PR upgrades Http.fs to 5.0.0 for  NetCore tests