### PR TITLE
Avoid early evaluation of `method` and `host`

### DIFF
--- a/src/Suave.Tests/HttpApplicatives.fs
+++ b/src/Suave.Tests/HttpApplicatives.fs
@@ -28,7 +28,7 @@ let applicativeTests cfg =
       Expect.equal res "A" "Should return A"
 
     testCase "url with spaces: pathScan" <| fun _ ->
-      let res = runWithConfig (pathScan "/foo/%s" (fun s -> OK s)) |> req HttpMethod.GET "/foo/get by" None
+      let res = runWithConfig (pathScan "/foo/%s" OK) |> req HttpMethod.GET "/foo/get by" None
       Expect.equal res "get by" "Should return 'get buy'"
 
     testCase "when not matching on Host" <| fun _ ->

--- a/src/Suave.Tests/Owin.fs
+++ b/src/Suave.Tests/Owin.fs
@@ -33,7 +33,7 @@ let owinUnit cfg =
     Dictionary(dict(List.map (fun (a,b) -> a,[|b|]) m), StringComparer.OrdinalIgnoreCase)
 
   let createOwin () =
-    let request = { HttpRequest.empty with ``method`` = HttpMethod.PUT }
+    let request = { HttpRequest.empty with rawMethod = "PUT" }
     new OwinApp.OwinContext("/", { HttpContext.empty with request = request })
     :> IDictionary<string, obj>
 
@@ -112,7 +112,7 @@ let owinUnit cfg =
         let subj =
           let request =
             { HttpRequest.empty with
-                url = Uri(requestUri)
+                rawPath = "/path"
                 headers = [("host","localhost")]
                 rawQuery = "q=a&b=c"
               }

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -5,9 +5,6 @@ open Suave.Sockets
 
 module Response =
 
-  open System
-  open System.IO
-
   let response (statusCode : HttpCode) (cnt : byte []) =
     fun (ctx : HttpContext) ->
       let response =
@@ -401,7 +398,6 @@ module Filters =
     logWithLevel LogLevel.Debug logger formatter
 
   open Suave.Sscanf
-  open ServerErrors
 
   let pathScan (pf : PrintfFormat<_,_,_,_,'t>) (h : 't ->  WebPart) : WebPart =
 

--- a/src/Suave/ParsingAndControl.fs
+++ b/src/Suave/ParsingAndControl.fs
@@ -2,27 +2,12 @@ namespace Suave
 
 /// Parsing and control flow handling for web requests
 module internal ParsingAndControl =
-  open System
-  open System.IO
-  open System.Text
-  open System.Diagnostics
-  open System.Net
-  open System.Net.Sockets
-  open System.Threading
-  open System.Threading.Tasks
-  open System.Collections.Generic
 
-  open Suave.Globals
-  open Suave.Compression
+  open System.IO
   open Suave.Sockets
-  open Suave.Sockets.Connection
   open Suave.Sockets.Control
-  open Suave.Sockets.SocketOp.Operators
   open Suave.Tcp
-  
   open Suave.Utils
-  open Suave.Utils.Bytes
-  open Suave.Utils.Parsing
   open Suave.Logging
   open Suave.Logging.Message
 
@@ -42,8 +27,6 @@ module internal ParsingAndControl =
     | HTTPS o -> 
       return! runtime.tlsProvider.wrap (connection,o)
     }
-
-  open System.Net.Sockets
 
   let inline cleanResponse (ctx : HttpContext) =
     { ctx with response = HttpResult.empty; userState = Map.empty }
@@ -150,14 +133,11 @@ module internal ParsingAndControl =
       return ()
     }
 
-
   /// Starts a new web worker, given the configuration and a web part to serve.
   let startWebWorkerAsync (bufferSize, maxOps) (webpart : WebPart) (runtime : HttpRuntime) runServer =
     startTcpIpServerAsync (requestLoop runtime webpart)
                           runtime.matchedBinding.socketBinding
                           runServer
-
-  open System.Reflection
 
   let resolveDirectory homeDirectory =
     match homeDirectory with

--- a/src/Suave/ParsingAndControl.fs
+++ b/src/Suave/ParsingAndControl.fs
@@ -111,7 +111,7 @@ module internal ParsingAndControl =
         | None ->
           logger.verbose (event "'result = None', exiting")
         | Some ctx ->
-          let! result'' = HttpOutput.addKeepAliveHeader ctx |> HttpOutput.run consumer
+          let! result'' = HttpOutput.run consumer (HttpOutput.addKeepAliveHeader ctx)
           match result'' with
           | Choice1Of2 result -> 
             match result with


### PR DESCRIPTION
By making them properties and carrying the original raw values with the request.

Plus some clean up.