### PR TITLE
Adding support for 303: See Other redirection.

### DIFF
--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -178,6 +178,17 @@ module Redirection =
 </html>"
       url HTTP_302.message))
 
+  let see_other url =
+    setHeader "Location" url
+    >=> setHeader "Content-Type" "text/html; charset=utf-8"
+    >=> response HTTP_303 (
+      UTF8.bytes(sprintf "<html>
+  <body>
+    <a href=\"%s\">%s</a>
+  </body>
+</html>"
+      url HTTP_303.message))
+
   let not_modified : WebPart =
     fun ctx -> { ctx with response = {status = HTTP_304.status; headers = []; content = Bytes [||]; writePreamble = true }} |> succeed
 

--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -443,6 +443,28 @@ module Redirection =
   val redirect : location:string -> WebPart
 
   /// <summary><para>
+  /// Composite:
+  /// </para><para>
+  /// HTTP/1.1 303 See Other
+  /// </para><para>
+  /// Location: 'location'
+  /// </para><para>
+  /// Content-Type: text/html; charset=utf-8
+  /// </para><para>
+  /// &lt;html&gt;
+  ///   &lt;body&gt;
+  ///    &lt;a href=&quot;'location'&quot;&gt;See Other&lt;/a&gt;
+  ///   &lt;/body&gt;
+  /// &lt;/html&gt;
+  /// </para><para>
+  /// The 303 (See Other) status code indicates that the server is
+  /// redirecting the user agent to a different resource, as indicated by a
+  /// URI in the Location header field, which is intended to provide an
+  /// indirect response to the original request.  
+  /// </para></summary>
+  val see_other : location:string -> WebPart
+
+  /// <summary><para>
   /// If the client has performed a conditional GET request and access is
   /// allowed, but the document has not been modified, the server SHOULD
   /// respond with this status code. The 304 response MUST NOT contain a


### PR DESCRIPTION
HTTP 303 support is useful when you accept a request to create a resource that takes time to create, and, once created, want to communicate the location where information about creating the resource can be found.  A typical flow using HTTP 303 would be as follows:

1. POST to /api/resource - returns `HTTP 202 Accepted`, with a `Location` header indicating `/api/task/1234` can provide details on the progress of creating it.
2. GET `/api/task/1234` - before the task is done, this returns `HTTP 200` with content providing task progress information about the resource being created.  If cancellation is supported, `DELETE /api/task/1234` would be a reasonable way to support it, and the content of the task could return that as a link.
3. GET `/api/task/1234` - once the task is done and the resource is created, this returns `HTTP 303: See Other` which indicates that the resource being created by the task is available now.  A `Location: /api/resource/5678` header redirects the user to the actual resource they tried to create in the first place.
4. GET `/api/resource/5678` - now that the resource is created, this returns `HTTP 200` with the resource's content.