### PR TITLE
Fixes multiple problems in last-modified handling

### DIFF
--- a/src/Suave/Utils/Parse.fs
+++ b/src/Suave/Utils/Parse.fs
@@ -1,4 +1,4 @@
-﻿namespace Suave.Utils
+namespace Suave.Utils
 
 [<RequireQualifiedAccess>]
 module Parse =
@@ -16,4 +16,5 @@ module Parse =
   let uint64 = parseUsing UInt64.TryParse
   let uri = parseUsing (fun s -> Uri.TryCreate(s, UriKind.RelativeOrAbsolute))
   let dateTime = parseUsing (fun s -> DateTime.TryParse(s, CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.RoundtripKind))
+  let dateTimeOffset = parseUsing (fun s -> DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.AssumeUniversal))
   let decimal = parseUsing (fun s -> Decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture))


### PR DESCRIPTION
* The header value wasn't in GMT (It was the time on the current server timezone with 'GMT' written after)
* On filesystems with millisecond precision times in fstat a 304 was never returned as the header value is only precise to the second. (All recent linux FS and windows NTFS are in this case)
* Last accessed time was used instead of last modified