### PR TITLE
Fixing sequence map bug for getHeaders

### DIFF
--- a/src/Suave/Headers.fs
+++ b/src/Suave/Headers.fs
@@ -57,7 +57,7 @@ module Headers =
   let getHeaders ctx =
     ctx.request.headers
     |> Seq.groupBy fst
-    |> Seq.map (fun (k,v) -> k, Seq.map fst v)
+    |> Seq.map (fun (k,v) -> k, Seq.map snd v)
     |> dict
     |> fun d -> new System.Collections.Generic.Dictionary<_,_>(d, System.StringComparer.OrdinalIgnoreCase)
     :> System.Collections.Generic.IDictionary<_,_>

--- a/src/Suave/Headers.fs
+++ b/src/Suave/Headers.fs
@@ -53,7 +53,7 @@ module Headers =
     |> Seq.filter (fst >> (=) lowerName)
     |> Seq.map snd
 
-  /// group headers by name and collect all headers in a dictionary.
+  /// group headers by name and collect all headers in a dictionary with format String<label>:Seq<String<values>>
   let getHeaders ctx =
     ctx.request.headers
     |> Seq.groupBy fst


### PR DESCRIPTION
Fixing sequence map bug for getHeaders which only takes labels instead of values