### PR TITLE
Using RegEx for parsing the boundary from the ContentType header.

### DIFF
--- a/src/Suave.Tests/Parsing.fs
+++ b/src/Suave.Tests/Parsing.fs
@@ -215,8 +215,17 @@ let testParseBoundary =
               "-idczlATz:FmvuIs'aHQSrGltky:Td")
              ("multipart/form-data; boundary=99233d57-854a-4b17-905b-ae37970e8a39",
               "99233d57-854a-4b17-905b-ae37970e8a39")
-             ("multipart/form-data; charset=utf8; boundary=---------------------------19533183328386942351998832384",
+             ("multipart/form-data; boundary=---------------------------19533183328386942351998832384",
               "---------------------------19533183328386942351998832384") ]
+           |> List.map compare
+           |> ignore
+
+      testCase "Matching boundaries with charset defined"
+      <| fun _ ->
+           [ ("multipart/form-data; charset=utf8; boundary=\"abc123 / + _,_.():=? as\"",
+              "abc123 / + _,_.():=? as")
+             ("multipart/form-mixed; charset=utf8; boundary=/tkQKiFqMgZt:mHzua_JFrUFWHgNid",
+              "/tkQKiFqMgZt:mHzua_JFrUFWHgNid")]
            |> List.map compare
            |> ignore
 

--- a/src/Suave/ConnectionFacade.fs
+++ b/src/Suave/ConnectionFacade.fs
@@ -374,7 +374,7 @@ type internal ConnectionFacade(connection: Connection, logger:Logger,matchedBind
 
         match partHeaders %% "content-type" with
         | Choice1Of2 x when String.startsWith "multipart/mixed" x ->
-          let subboundary = "--" + (x.Substring(x.IndexOf('=') + 1) |> String.trimStart |> String.trimc '"')
+          let subboundary = "--" + parseBoundary x
           do! parseMultipartMixed fieldName subboundary
           let a = reader.skip (boundary.Length)
           return ()
@@ -453,7 +453,7 @@ type internal ConnectionFacade(connection: Connection, logger:Logger,matchedBind
           return ()
 
         | Choice1Of2 ce when String.startsWith "multipart/form-data" ce ->
-          let boundary = "--" + (ce |> String.substring (ce.IndexOf('=') + 1) |> String.trimStart |> String.trimc '"')
+          let boundary = "--" + parseBoundary ce
 
           logger.verbose (eventX "Parsing multipart")
           do! parseMultipart boundary

--- a/src/Suave/Utils/Parsing.fs
+++ b/src/Suave/Utils/Parsing.fs
@@ -63,8 +63,8 @@ let headerParams (header : string) =
 /// Parse the boundary from the value of the Content-Type header.
 /// Based on the allowed set from
 /// https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1
-/// it allows alphanumeric characters, punctuations and spaces (except at the
-/// end. Qutation marks seem to be optional as well.
+/// It allows alphanumeric characters, punctuations and spaces (except at the
+/// end). Quotation marks seem to be optional as well.
 ///
 let parseBoundary contentType =
   let pattern = "boundary=\"?([a-zA-Z0-9'\(\)+_,-.\/:=? ]*)(?<! )\"?"

--- a/src/Suave/Utils/Parsing.fs
+++ b/src/Suave/Utils/Parsing.fs
@@ -61,6 +61,11 @@ let headerParams (header : string) =
   parseKVPairs parts
 
 /// Parse the boundary from the value of the Content-Type header.
+/// Based on the allowed set from
+/// https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1
+/// it allows alphanumeric characters, punctuations and spaces (except at the
+/// end. Qutation marks seem to be optional as well.
+///
 let parseBoundary contentType =
-  let pattern = "boundary=(\w*)"
+  let pattern = "boundary=\"?([a-zA-Z0-9'\(\)+_,-.\/:=? ]*)(?<! )\"?"
   Regex.Match(contentType, pattern).Groups.[1].Value

--- a/src/Suave/Utils/Parsing.fs
+++ b/src/Suave/Utils/Parsing.fs
@@ -5,6 +5,7 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Net
+open System.Text.RegularExpressions
 
 /// Gets whether the passed ip is a local IPv4 or IPv6 address.
 /// Example: 127.0.0.1, ::1 return true. If the IP cannot be parsed,
@@ -58,3 +59,8 @@ let parseKVPairs arr =
 let headerParams (header : string) =
   let parts = header |> String.splita ';' |> Array.map String.trimStart
   parseKVPairs parts
+
+/// Parse the boundary from the value of the Content-Type header.
+let parseBoundary contentType =
+  let pattern = "boundary=(\w*)"
+  Regex.Match(contentType, pattern).Groups.[1].Value


### PR DESCRIPTION
As detailed in the issue #759, the current parsing of the boundary does not respect the `charset` property.

The PR proposes a fix to use a regular expression to parse the boundary from the ContentType header value based on [RFC2046](https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1).  It allows alphanumeric characters, punctuations and spaces (except at the end). Quotation marks seem to be optional as well.

```fsharp
let parseBoundary contentType =
  let pattern = "boundary=\"?([a-zA-Z0-9'\(\)+_,-.\/:=? ]*)(?<! )\"?"
  Regex.Match(contentType, pattern).Groups.[1].Value
```

```fsharp
| Choice1Of2 ce when String.startsWith "multipart/form-data" ce ->
  let boundary = "--" + parseBoundary ce
```

Changed for `"multipart/form-data"` and `"multipart/mixed"` in the code.

---

Input:

```
Content-Type = "multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__"
```

Original result:
```
 --utf-8; boundary=__X_PAW_BOUNDARY__
```

New results:
```
'multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__' => __X_PAW_BOUNDARY__
'multipart/form-data; boundary=__X_PAW_BOUNDARY__' => __X_PAW_BOUNDARY__
'multipart/form-data; boundary=__X_PAW_BOUNDARY__ charset=utf-8;' => __X_PAW_BOUNDARY__
'multipart/form-data;' => (null)
```