### PR TITLE
bugfix/issue-780-safe-decode-invalid-tokens

### DIFF
--- a/.github/workflows/build-suave.yml
+++ b/.github/workflows/build-suave.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 7.0.200
     - name: Build
       run: ./build.sh

--- a/src/Suave/Utils/ASCII.fs
+++ b/src/Suave/Utils/ASCII.fs
@@ -40,3 +40,14 @@ let encodeBase64 (s : string) =
 let decodeBase64 (s : string) =
   let bytes = Convert.FromBase64String s
   Encoding.ASCII.GetString bytes
+
+/// Try to convert the passed string `s`, which may be a valid Base64 encoding, to a
+/// CLR string, going through ASCII.
+let tryDecodeBase64 (s : string) =
+  try
+    let bytes = Convert.FromBase64String s
+    Encoding.ASCII.GetString bytes
+    |> Some
+  with
+  | :? FormatException ->
+    None


### PR DESCRIPTION
Handle invalid header case for basic auth

Closes https://github.com/SuaveIO/suave/issues/780