### PR TITLE
Fix CPU spin on half-closed WebSocket / silent body truncation

### DIFF
--- a/src/Suave.Tests/WebSocket.fs
+++ b/src/Suave.Tests/WebSocket.fs
@@ -3,6 +3,8 @@ module Suave.Tests.WebSocket
 open Expecto
 
 open System
+open System.IO
+open System.Net.Sockets
 open Websocket.Client
 open System.Text
 open System.Threading
@@ -143,7 +145,7 @@ let websocketTests cfg =
     else
       false
 
-  let testCase webSocketUrl subprotocols testName fn =
+  let websocketTestCase webSocketUrl subprotocols testName fn =
     testCase testName <| fun _ ->
       use mre = new ManualResetEvent(false)
       let clientFactory _=
@@ -158,7 +160,7 @@ let websocketTests cfg =
 
   let websocketTests websocketUrl subprotocols = 
     testList (sprintf "websocket tests for url %s" websocketUrl) [
-      testCase websocketUrl subprotocols "text echo test" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "text echo test" <| fun mre clientWebSocket ->
         let message = "Hello Websocket World!"
         let echo : string ref = ref ""
 
@@ -175,7 +177,7 @@ let websocketTests cfg =
 
         Expect.equal echo.Value message "Should be echoed"
 
-      testCase websocketUrl subprotocols "subprotocol support test" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "subprotocol support test" <| fun mre clientWebSocket ->
         let message = "Subprotocol"
         let echo : string ref = ref ""
 
@@ -195,7 +197,7 @@ let websocketTests cfg =
         else
           Expect.equal websocketAppSupportSubprotocol echo.Value "Should test equal"
 
-      testCase websocketUrl [|"unsupport.suave.io"|] "subprotocol unsupport test" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl [|"unsupport.suave.io"|] "subprotocol unsupport test" <| fun mre clientWebSocket ->
         if websocketUrl = websocketAppSubprotocolUrl then
           let message = "Subprotocol"
           let echo : string ref = ref ""
@@ -211,7 +213,7 @@ let websocketTests cfg =
 
           Expect.equal echo.Value "" "Should match no protocol"
 
-      testCase websocketUrl subprotocols "socket binary payload 7bit" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "socket binary payload 7bit" <| fun mre clientWebSocket ->
         let message = "BinaryRequest7bit"
         let echo : byte array ref = ref [||]
 
@@ -228,7 +230,7 @@ let websocketTests cfg =
 
         Expect.isTrue (testByteArray (int PayloadSize.Bit7) echo.Value) "Should test equal"
 
-      testCase websocketUrl subprotocols "socket binary payload 16bit" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "socket binary payload 16bit" <| fun mre clientWebSocket ->
         let message = "BinaryRequest16bit"
         let echo : byte array ref = ref [||]
 
@@ -245,7 +247,7 @@ let websocketTests cfg =
 
         Expect.isTrue (testByteArray (int PayloadSize.Bit16) echo.Value) "Should be echoed"
 
-      testCase websocketUrl subprotocols "socket binary payload 32bit" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "socket binary payload 32bit" <| fun mre clientWebSocket ->
         let message = "BinaryRequest32bit"
         let echo : byte array ref = ref [||]
 
@@ -261,7 +263,7 @@ let websocketTests cfg =
 
         Expect.isTrue (testByteArray (int PayloadSize.Bit32) echo.Value) "Should be echoed"
 
-      testCase websocketUrl subprotocols "echo large number of messages to client" <| fun mre clientWebSocket ->
+      websocketTestCase websocketUrl subprotocols "echo large number of messages to client" <| fun mre clientWebSocket ->
         let amountOfMessages = 1000
         let echo = ref []
         let count = ref 0
@@ -289,4 +291,44 @@ let websocketTests cfg =
   
   testList "websocket tests" [ websocketTests websocketAppUrl [||];
                                websocketTests websocketAppReusingBuffersUrl [||];
-                               websocketTests websocketAppSubprotocolUrl [|websocketAppSupportSubprotocol|];]
+                               websocketTests websocketAppSubprotocolUrl [|websocketAppSupportSubprotocol|];
+                               testCase "raw tcp half-close exits websocket handler promptly" <| fun _ ->
+                                 use handlerExited = new ManualResetEventSlim(false)
+                                 let websocketAppHalfClose (webSocket : WebSocket) =
+                                   fun _ -> SocketOp.ofTask(task {
+                                     let mutable continueLoop = true
+                                     while continueLoop do
+                                       let! msgResult = webSocket.read()
+                                       match msgResult with
+                                       | Ok _
+                                       | Result.Error _ -> continueLoop <- false
+                                     handlerExited.Set()
+                                     return Ok()
+                                   })
+
+                                 let ctx = runWithConfig (Filters.path "/websocket-half-close" >=> handShake websocketAppHalfClose)
+
+                                 withContext (fun _ ->
+                                   use client = new TcpClient(ip, port)
+                                   client.ReceiveTimeout <- 2000
+                                   use stream = client.GetStream()
+                                   let request =
+                                     sprintf "GET /websocket-half-close HTTP/1.1\r\nHost: %s:%i\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n" ip port
+                                     |> Encoding.ASCII.GetBytes
+                                   stream.Write(request, 0, request.Length)
+                                   stream.Flush()
+
+                                   use reader = new StreamReader(stream, Encoding.ASCII, false, 1024, true)
+                                   let statusLine = reader.ReadLine()
+                                   Expect.equal statusLine "HTTP/1.1 101 Switching Protocols" "should complete websocket upgrade"
+
+                                   let rec readHeaders () =
+                                     let line = reader.ReadLine()
+                                     if not (String.IsNullOrEmpty line) then readHeaders ()
+                                   readHeaders ()
+
+                                   client.Client.Shutdown(SocketShutdown.Send)
+
+                                   let exited = handlerExited.Wait(TimeSpan.FromSeconds 2.0)
+                                   Expect.isTrue exited "handler should exit shortly after peer half-closes the socket")
+                                   ctx ]

--- a/src/Suave/ConnectionFacade.fs
+++ b/src/Suave/ConnectionFacade.fs
@@ -250,7 +250,13 @@ type ConnectionFacade(connection: Connection, runtime: HttpRuntime, connectionPo
             let target = new Span<byte>(rawForm, offset, count)
             source.CopyTo(target)
             offset <- offset + count)
-        return Ok (rawForm)
+        if offset = contentLength then
+          return Ok rawForm
+        else
+          // readPostData aborts silently on EOF / cancellation. Without this
+          // check the caller would observe a successfully-parsed request whose
+          // body is silently truncated and zero-padded.
+          return Result.Error (ConnectionError (sprintf "short read on request body: expected %d bytes, got %d" contentLength offset))
       })
 
   member val Connection = connection with get,set

--- a/src/Suave/WebSocket.fs
+++ b/src/Suave/WebSocket.fs
@@ -147,7 +147,13 @@ module WebSocket =
             let target = new Span<byte>(arr,offset,count)
             source.CopyTo(target)
             offset <- offset + count)
-        return Ok(arr)
+        if offset = n then
+          return Ok arr
+        else
+          // readPostData aborts silently on EOF / cancellation; surface it as
+          // a connection error so the WebSocket reader does not interpret the
+          // zero-filled buffer as a valid frame and spin on it forever.
+          return Result.Error (ConnectionError (sprintf "short read: expected %d bytes, got %d" n offset))
       })
 
   let readBytesIntoByteSegment retrieveByteSegment (connection : Connection) (n : int) : SocketOp<ByteSegment> =
@@ -168,7 +174,10 @@ module WebSocket =
           let target = byteSegment.Span.Slice(offset,count)
           source.CopyTo(target)
           offset <- offset + count)
-        return Ok(byteSegment)
+        if offset = n then
+          return Ok byteSegment
+        else
+          return Result.Error (ConnectionError (sprintf "short read: expected %d bytes, got %d" n offset))
       })
 
   type internal Cont<'t> = 't -> unit


### PR DESCRIPTION
readPostData aborts silently on EOF or cancellation, leaving the caller with a zero-filled buffer and no indication that the read was short.

In WebSocket.readBytes / readBytesIntoByteSegment this caused the frame parser to see opcode=0 length=0 (a zero-length Continuation frame), return immediately, and loop forever - pegging a CPU core after the peer half-closed the connection.

In ConnectionFacade.getRawPostData the same bug silently truncated HTTP/1 request bodies, returning Ok with a partially-zeroed buffer instead of surfacing the broken connection.

The HTTP/2 reader (Http2.readBytes) already guards against this with an 'if offset = n' check; apply the same fix to the other three call sites.

Added a regression test in `src/Suave.Tests/WebSocket.fs` that opens a raw TCP socket, performs a valid WebSocket upgrade handshake, half-closes the client send side, and asserts the handler exits within a deadline.