### PR TITLE
fix escaping in getting-started.html

### DIFF
--- a/website/content/docs/getting-started.html
+++ b/website/content/docs/getting-started.html
@@ -183,10 +183,11 @@ let app =
       | Choice1Of2 message -> OK (sprintf "Received: %s" message)
       | Choice2Of2 _ -> OK "No message")
     
-    GET >=> OK "<form method='POST'>
-      <input name='message'>
-      <button>Send</button>
-    </form>"
+    GET >=> OK """
+      &lt;form method=&quot;POST&quot;&gt;
+        &lt;input name=&quot;message&quot;&gt;
+        &lt;button&gt;Send&lt;/button&gt;
+      &lt;/form&gt;"""
   ]
 
 startWebServer defaultConfig app</code></pre>


### PR DESCRIPTION
site have problem with "POST Data & Forms" example

before:
look to this example: https://suave.io/docs/getting-started.html
render input and coping this:
```
    //...
    GET >=> OK "
      
      Send
    "
    //...
```
after:
render text and coping correctly
<img width="655" height="397" alt="image" src="https://github.com/user-attachments/assets/af8ca82a-ed16-4e63-aa8e-091010cc1265" />
