### PR TITLE
Set up Cursor Cloud dev environment for Suave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Suave is an F# web server **library** (a small monorepo of NuGet packages: `Suave`, `Suave.Json`, `Suave.DotLiquid`, tests, examples, and a docs `website`). It builds and tests entirely in-process — there is **no database or external service** to run.
+
+### Toolchain (already installed in the VM snapshot)
+- .NET SDK `10.0.102` (pinned by `global.json`) plus the .NET 6 runtime (needed by the FAKE build project, which targets `net6.0`) live in `~/.dotnet`, symlinked at `/usr/local/bin/dotnet`.
+- Dependencies use **Paket**, not plain `PackageReference`. The startup update script runs `dotnet tool restore` (restores the `paket` + `fake-cli` local tools from `.config/dotnet-tools.json`) followed by `dotnet paket restore`. Always ensure a Paket restore has run before building.
+
+### Build / test / run
+- Build the solution: `dotnet build Suave.sln` (or the FAKE target `dotnet run --project ./build/build.fsproj -- -t Build`). Expect ~46 warnings, 0 errors.
+- Run the test suite (same command CI uses): `dotnet run -c Release --framework net10.0 --project src/Suave.Tests -- --summary --sequenced`. Tests self-host Suave on loopback ports.
+- Run an example server (each defaults to HTTP `127.0.0.1:8080`; the `website` binds `0.0.0.0:8080` — run only one at a time): e.g. `dotnet run --project examples/RouterExample`, then hit `http://127.0.0.1:8080/`.
+
+### Non-obvious caveats
+- **Do not `source .env` / run `build.sh` as-is.** `.env` sets a Mono-based `FrameworkPathOverride` (`dirname $(which mono)/...`); Mono is not installed, so this yields a bogus path. It is unnecessary for the .NET SDK build — run the underlying `dotnet` commands directly instead.
+- **The websocket test list can flaky-hang in this VM.** With `--sequenced`, the large 32-bit (66000-byte) binary-payload test under `/websocketAppSubprotocolUrl` occasionally blocks forever (the test uses `mre.WaitOne()` with no timeout, so a single missed frame over loopback hangs the whole run). The identical test passes for the other websocket URLs, and CI runs the full suite green in ~2m23s — so treat this as a flaky test in the VM, **not** an environment breakage. For a deterministic pass, filter to a list, e.g. `--filter-test-list miscellaneous` (364 tests), or be prepared to kill and retry the full run.
+- No linter/formatter is configured; code style is only enforced by `.editorconfig` (2-space indent).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Suave (F# web server library on .NET) and documents durable, non-obvious run/test caveats for future agents.

- Installs .NET SDK `10.0.102` (per `global.json`) + the .NET 6 runtime (required by the `net6.0` FAKE build project) into the VM snapshot; `dotnet` is symlinked at `/usr/local/bin/dotnet`.
- Startup **update script**: `dotnet tool restore` then `dotnet paket restore` (Paket-managed deps).
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section (toolchain, build/test/run commands, and non-obvious caveats).

## Environment verification

| Step | Command | Result |
| --- | --- | --- |
| Build | `dotnet build Suave.sln` | 0 errors (46 warnings) |
| Test | `dotnet run -c Release --framework net10.0 --project src/Suave.Tests -- --summary --sequenced --filter-test-list miscellaneous` | 364 passed, 0 failed |
| Run (hello world) | `dotnet run --project examples/RouterExample` → HTTP requests | All routes 200/404 as expected |

## Hello-world demo

Ran the `RouterExample` Suave server and exercised routing, path/nested params, all HTTP verbs, prefixed and wildcard routes, plus 404 handling.

[suave_router_browser_demo.mp4](https://cursor.com/agents/bc-07761c6c-02f5-4c68-b829-097cc3102af4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuave_router_browser_demo.mp4)

[Suave Router Example landing page](https://cursor.com/agents/bc-07761c6c-02f5-4c68-b829-097cc3102af4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frouter_home_page.webp)
[User lookup by path parameter](https://cursor.com/agents/bc-07761c6c-02f5-4c68-b829-097cc3102af4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frouter_user_lookup.webp)

## Notable caveats (captured in AGENTS.md)

- Do **not** `source .env` / run `build.sh` verbatim: `.env` sets a Mono-based `FrameworkPathOverride` and Mono isn't installed; it's unnecessary for the .NET SDK build.
- The full websocket test list can **flaky-hang** in this VM on the large 32-bit (66000-byte) binary-payload subprotocol test (`mre.WaitOne()` with no timeout over loopback). The identical test passes for the other websocket URLs and CI runs the whole suite green in ~2m23s, so this is a flaky test in the VM, not an environment breakage.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07761c6c-02f5-4c68-b829-097cc3102af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07761c6c-02f5-4c68-b829-097cc3102af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

