### PR TITLE
Relax FSharp.Core dependency constraint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Allow consuming projects to use FSharp.Core versions newer than 10.0.102 (#840)
 * Refresh `README.md` to describe current v3.x capabilities and remove the legacy Jekyll `docs/` tree in favor of `website/` (guides) and `docs-api/` (API reference)
 * Modernize the reverse proxy to use `System.Net.Http.HttpClient` (shared, static instance) instead of the obsolete `WebRequest`/`HttpWebRequest` API
 * Proxy: set `X-Forwarded-For` from the client address (appending to any existing chain), target `Host` at the upstream authority, and forward the client's host/scheme as `X-Forwarded-Host`/`X-Forwarded-Proto`

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ source https://api.nuget.org/v3/index.json
 framework net10.0
 storage none
 
-nuget FSharp.Core
+nuget FSharp.Core >= 10.0.102
 nuget Microsoft.Extensions.FileProviders.Embedded
 nuget DotLiquid
 nuget Websocket.Client


### PR DESCRIPTION
Suave 3.4.4 pins consumers to FSharp.Core 10.0.102, causing NU1608 when applications select a newer compatible version.

Declare 10.0.102 as the minimum supported version instead. Paket now emits an open-ended NuGet dependency range, allowing newer FSharp.Core versions while preserving the existing minimum.

Validated by packing Suave and restoring a consumer with FSharp.Core 10.1.400 without NU1608.

Fixes: #840