### PR TITLE
Set licenseUrl to the canonical licenses.nuget.org address

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ## New in v3.4.5 (Released 2026-08-26)
-* Packages now declare the Apache-2.0 license as an SPDX expression (`licenseExpression`) instead of the deprecated `licenseUrl`, and carry repository metadata
+* Packages now declare the Apache-2.0 license as an SPDX expression (`licenseExpression`, with `licenseUrl` kept at the canonical `licenses.nuget.org` address for older clients) and carry repository metadata
 * Allow consuming projects to use FSharp.Core versions newer than 10.0.102 (#840)
 * Refresh `README.md` to describe current v3.x capabilities and remove the legacy Jekyll `docs/` tree in favor of `website/` (guides) and `docs-api/` (API reference)
 * Modernize the reverse proxy to use `System.Net.Http.HttpClient` (shared, static instance) instead of the obsolete `WebRequest`/`HttpWebRequest` API

--- a/src/Suave.DotLiquid/paket.template
+++ b/src/Suave.DotLiquid/paket.template
@@ -3,6 +3,7 @@ authors Ademar Gonzalez
 owners Ademar Gonzalez
 description Suave.DotLiquid provides Liquid templates for Suave web server.
 licenseExpression Apache-2.0
+licenseUrl https://licenses.nuget.org/Apache-2.0
 repositoryUrl https://github.com/SuaveIO/suave
 repositoryType git
 iconUrl https://raw.githubusercontent.com/SuaveIO/resources/master/images/head_trans.png

--- a/src/Suave.Json/paket.template
+++ b/src/Suave.Json/paket.template
@@ -3,6 +3,7 @@ authors Ademar Gonzalez
 owners Ademar Gonzalez
 description Suave.Json provides a small JSON serialization layer for Suave, backed by DataContractJsonSerializer. This package relies on runtime reflection and is NOT compatible with .NET Native AOT.
 licenseExpression Apache-2.0
+licenseUrl https://licenses.nuget.org/Apache-2.0
 repositoryUrl https://github.com/SuaveIO/suave
 repositoryType git
 iconUrl https://raw.githubusercontent.com/SuaveIO/resources/master/images/head_trans.png

--- a/src/Suave/paket.template
+++ b/src/Suave/paket.template
@@ -3,6 +3,7 @@ authors Ademar Gonzalez
 owners Ademar Gonzalez
 description Suave is a simple web development F# library providing a lightweight web server and a set of combinators to manipulate route flow and task composition.
 licenseExpression Apache-2.0
+licenseUrl https://licenses.nuget.org/Apache-2.0
 repositoryUrl https://github.com/SuaveIO/suave
 repositoryType git
 iconUrl https://raw.githubusercontent.com/SuaveIO/resources/master/images/head_trans.png


### PR DESCRIPTION
nuget.org rejects a package that carries a <license type="expression"> unless <licenseUrl> is also present and points at
https://licenses.nuget.org/<expression>, so that older clients still resolve the license:

  400 To provide a better experience for older clients when a license
  expression is specified, <licenseUrl> must be set to
  'https://licenses.nuget.org/Apache-2.0'.

`dotnet pack` synthesizes that url from the expression; paket does not, so set both explicitly in the templates. The v3.4.5 push failed on the first package, so nothing was published under that version.