### PR TITLE
Fix static file fallback for missing resources

### DIFF
--- a/src/Suave.Tests/HttpFile.fs
+++ b/src/Suave.Tests/HttpFile.fs
@@ -109,6 +109,20 @@ let ``ETag support`` cfg =
       Expect.equal a b "Two consecutive calls should return the same ETag"
       Expect.stringStarts a "W/\"" "ETag should be a weak validator"
 
+    testCase "missing file falls through to the next WebPart" <| fun _ ->
+      let app =
+        choose [
+          Files.browseHome
+          RequestErrors.NOT_FOUND "fallback"
+        ]
+      let status, body =
+        runWithConfig app
+        |> reqResp HttpMethod.GET "/file-that-does-not-exist.txt" "" None None DecompressionMethods.None id (fun response ->
+             response.StatusCode,
+             contentString response)
+      Expect.equal status HttpStatusCode.NotFound "Should use the fallback response"
+      Expect.equal body "fallback" "Should return the fallback body"
+
     testCase "If-None-Match with matching ETag returns 304 Not Modified" <| fun _ ->
       let setIfNoneMatch (req : HttpRequestMessage) =
         req.Headers.TryAddWithoutValidation("If-None-Match", expectedEtag) |> ignore

--- a/src/Suave/Combinators.fs
+++ b/src/Suave/Combinators.fs
@@ -448,7 +448,11 @@ module ServeResource =
                 (send : string -> bool -> WebPart)
                 ctx =
 
-    let etag = getEtag key
+    let resourceExists = exists key
+
+    let etag =
+      if resourceExists then getEtag key
+      else None
 
     let setEtagHeader : WebPart =
       match etag with
@@ -475,7 +479,7 @@ module ServeResource =
              t = "*" || t = e)
       | _ -> false
 
-    if exists key then
+    if resourceExists then
       let mimes = ctx.runtime.mimeTypesMap (getExtension key)
       match mimes with
       | Some value ->


### PR DESCRIPTION
`ServeResource.resource` calculated an ETag before checking whether a resource existed.
For missing files, `Files.browseHome` returned HTTP 500 instead of falling through to the next `WebPart`.
This change checks for existence first and adds a regression test for fallback behavior.
