### PR TITLE
Add hideStartupMessage config flag to silence the listener banner

### DIFF
--- a/examples/Example/Program.fs
+++ b/examples/Example/Program.fs
@@ -181,6 +181,7 @@ let main argv =
       compressedFilesFolder = None
       cookieSerialiser      = new BinaryFormatterSerialiser()
       hideHeader            = false
+      hideStartupMessage    = false
       maxContentLength      = 1000000
       healthCheckEnabled    = true
       healthCheckIntervalMs = 30000

--- a/src/Suave/Http.fs
+++ b/src/Suave/Http.fs
@@ -409,6 +409,9 @@ module Http =
       matchedBinding    : HttpBinding
       cookieSerialiser  : CookieSerialiser
       hideHeader        : bool
+      /// Make this true to skip the "Smooth! Suave ... listener started" console
+      /// message written when the TCP listener starts. Defaults to false.
+      hideStartupMessage : bool
       maxContentLength  : int
       /// Optional sink factory for streaming multipart file parts.
       /// When <c>None</c> (the default), each file part is buffered to a temp file on disk.
@@ -504,11 +507,12 @@ module Http =
         matchedBinding    = HttpBinding.defaults
         cookieSerialiser  = new BinaryFormatterSerialiser()
         hideHeader        = false
+        hideStartupMessage = false
         maxContentLength  = 1024
         filePartSink      = None }
 
     let create serverKey errorHandler mimeTypes homeDirectory compressionFolder
-           (*logger*) cookieSerialiser hideHeader maxContentLength binding =
+           (*logger*) cookieSerialiser hideHeader hideStartupMessage maxContentLength binding =
       { serverKey         = serverKey
         errorHandler      = errorHandler
         mimeTypesMap      = mimeTypes
@@ -517,6 +521,7 @@ module Http =
         matchedBinding    = binding
         cookieSerialiser  = cookieSerialiser
         hideHeader        = hideHeader
+        hideStartupMessage = hideStartupMessage
         maxContentLength  = maxContentLength
         filePartSink      = None }
 

--- a/src/Suave/Http.fsi
+++ b/src/Suave/Http.fsi
@@ -259,6 +259,9 @@ module Http =
       matchedBinding    : HttpBinding
       cookieSerialiser  : CookieSerialiser
       hideHeader        : bool
+      /// Make this true to skip the "Smooth! Suave ... listener started" console
+      /// message written when the TCP listener starts. Defaults to false.
+      hideStartupMessage : bool
       maxContentLength  : int
       /// Optional sink factory for streaming multipart file parts without a temp file.
       /// When <c>None</c> (the default), each file part is buffered to a temporary file on disk.
@@ -340,7 +343,7 @@ module Http =
                -> mimeTypes:MimeTypesMap -> homeDirectory:string
                -> compressionFolder:string (*-> logger:Logger*)
                -> cookieSerialiser:CookieSerialiser
-               -> hideHeader:bool -> maxContentLength:int
+               -> hideHeader:bool -> hideStartupMessage:bool -> maxContentLength:int
                -> binding:HttpBinding
                -> HttpRuntime
 

--- a/src/Suave/SuaveConfig.fs
+++ b/src/Suave/SuaveConfig.fs
@@ -48,6 +48,11 @@ type SuaveConfig =
     /// every response. Defaults to false.
     hideHeader            : bool
 
+    /// Make this true, if you want Suave not to print the "Smooth! Suave ...
+    /// listener started" message to the console when the server starts listening.
+    /// Defaults to false.
+    hideStartupMessage    : bool
+
     /// Maximun upload size in bytes
     maxContentLength      : int
 
@@ -90,6 +95,7 @@ type SuaveConfig =
   member x.withHomeFolder(v)            = { x with homeFolder = v }
   member x.withCompressedFilesFolder(v) = { x with compressedFilesFolder = v }
   member x.withHiddenHeader(v)          = { x with hideHeader = v }
+  member x.withHideStartupMessage(v)    = { x with hideStartupMessage = v }
   member x.withMaxContentLength(v)      = { x with maxContentLength = v }
   member x.withHealthCheckEnabled(v)    = { x with healthCheckEnabled = v }
   member x.withHealthCheckIntervalMs(v) = { x with healthCheckIntervalMs = v }
@@ -113,6 +119,7 @@ module SuaveConfig =
                          compressionFolder
                          config.cookieSerialiser
                          config.hideHeader
+                         config.hideStartupMessage
                          config.maxContentLength
     fun binding -> { createRuntime binding with filePartSink = config.filePartSink }
 

--- a/src/Suave/Tcp.fs
+++ b/src/Suave/Tcp.fs
@@ -334,10 +334,11 @@ let runServerEx acceptorCount maxConcurrentOps bufferSize (binding: SocketBindin
       let ipAddress = startData.binding.ip.ToString()
       let port = startData.binding.port
 
-      if effective > 1 then
-        Console.WriteLine($"Smooth! Suave v{Globals.SuaveVersion} listener started in {startedListeningMilliseconds} ms with binding {ipAddress}:{port} ({effective} acceptors)")
-      else
-        Console.WriteLine($"Smooth! Suave v{Globals.SuaveVersion} listener started in {startedListeningMilliseconds} ms with binding {ipAddress}:{port}")
+      if not runtime.hideStartupMessage then
+        if effective > 1 then
+          Console.WriteLine($"Smooth! Suave v{Globals.SuaveVersion} listener started in {startedListeningMilliseconds} ms with binding {ipAddress}:{port} ({effective} acceptors)")
+        else
+          Console.WriteLine($"Smooth! Suave v{Globals.SuaveVersion} listener started in {startedListeningMilliseconds} ms with binding {ipAddress}:{port}")
 
       // Create one connection pool per acceptor so each accept loop pops from
       // its own thread-local-ish pool, removing cross-acceptor contention.

--- a/src/Suave/Web.fs
+++ b/src/Suave/Web.fs
@@ -82,6 +82,7 @@ module Web =
       compressedFilesFolder = None
       cookieSerialiser      = new BinaryFormatterSerialiser()
       hideHeader            = false
+      hideStartupMessage    = false
       maxContentLength      = 10000000 // 10 megabytes
       healthCheckEnabled    = true   // Enable connection health monitoring
       healthCheckIntervalMs = 30000  // Check every 30 seconds


### PR DESCRIPTION
Apps that embed Suave as a dev server (e.g. fsdocs watch --verbosity quiet) had no way to keep console output clean short of redirecting Console.Out for the whole process, since hideHeader only affects the HTTP Server response header. SuaveConfig.hideStartupMessage (and the matching HttpRuntime field) now lets callers opt out of the "Smooth! Suave ... listener started" line printed in Tcp.fs. Defaults to false, so existing behavior is unchanged. 

Fixes #849.

